### PR TITLE
Fix endif jinja closing tag in install file

### DIFF
--- a/ansible/roles/k3s/templates/calico-installation.yaml.j2
+++ b/ansible/roles/k3s/templates/calico-installation.yaml.j2
@@ -13,6 +13,6 @@ spec:
       encapsulation: None
       {% else %}
       encapsulation: VXLANCrossSubnet
-      {% end %}
+      {% endif %}
       natOutgoing: Enabled
       nodeSelector: all()


### PR DESCRIPTION
Ansible playbook was failing with the below error due to incorrectly closed Jinja tag

fatal: [k8s-control-node]: FAILED! => {"changed": false, "msg": "AnsibleError: template error while templating string: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'endif'. The innermost block that needs to be closed is 'if'.. String: ---\napiVersion: operator.tigera.io/v1\nkind: Installation\nmetadata:\n  name: default\nspec:\n  calicoNetwork:\n    # Note: The ipPools section cannot be modified post-install.\n    ipPools:\n    - blockSize: 26\n      cidr: \"{{ k3s_server[\"cluster-cidr\"] }}\"\n      {% if calico.bgp.enabled is defined and calico.bgp.enabled %}\n      encapsulation: None\n      {% else %}\n      encapsulation: VXLANCrossSubnet\n      {% end %}\n      natOutgoing: Enabled\n      nodeSelector: all()\n"}