### PR TITLE
Fix missing spaces

### DIFF
--- a/server/ansible/roles/k3s/tasks/secrets.yml
+++ b/server/ansible/roles/k3s/tasks/secrets.yml
@@ -37,4 +37,4 @@
         ca.crt: "{{ slurped_etcd_ca_file.content }}"
         cert.pem: "{{ slurped_etcd_cert_file.content }}"
         key.pem: "{{ slurped_etcd_cert_key_file.content }}"
-  dest: "{{ k3s_server_manifests_dir }}/coredns-etcd-secret.yaml"
+    dest: "{{ k3s_server_manifests_dir }}/coredns-etcd-secret.yaml"


### PR DESCRIPTION
**Description of the change**

There are spaces missing in this task which causes the playbook to fail with:

`ERROR! conflicting action statements: ansible.builtin.copy, dest`

This changes adds the missing spaces.

**Benefits**

Playbook works.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
