### PR TITLE
chore: migrate lb svc to services vlan

### DIFF
--- a/bootstrap/helmfile.d/01-apps.yaml
+++ b/bootstrap/helmfile.d/01-apps.yaml
@@ -18,7 +18,7 @@ releases:
         command: bash
         args:
           - -c
-          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliuml2announcementpolicies.cilium.io ciliumbgpadvertisements.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpclusterconfigs.cilium.io &>/dev/null; do sleep 5; done
+          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliumbgpadvertisements.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpclusterconfigs.cilium.io &>/dev/null; do sleep 5; done
         events:
           - postsync
         showlogs: true

--- a/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
       streams:
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.42.124
+          lbipam.cilium.io/ips: 192.168.69.124
         externalTrafficPolicy: Cluster
         ports:
           streams-rtsp:
@@ -99,7 +99,7 @@ spec:
             webrtc:
               listen: :8555
               candidates:
-                - 192.168.42.124:8555
+                - 192.168.69.124:8555
                 - stun:8555
               ice_servers:
                 - urls:

--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
               tag: 2025.9.4@sha256:55c7db16301626265c6c8132985137ca0798303773dafa244e562353baa93a6f
             env:
               TZ: America/New_York
-              HASS_HTTP_TRUSTED_PROXY_1: 192.168.42.0/24
+              HASS_HTTP_TRUSTED_PROXY_1: 192.168.69.0/24
               HASS_HTTP_TRUSTED_PROXY_2: 10.42.0.0/16
             envFrom:
               - secretRef:

--- a/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mosquitto.turbo.ac
-          lbipam.cilium.io/ips: 192.168.42.129
+          lbipam.cilium.io/ips: 192.168.69.129
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
               tag: 1.42.2.10156@sha256:9ad8a3506e1d8ebda873a668603c1a2c10e6887969564561be669efd65ae8871
             env:
               TZ: America/New_York
-              PLEX_ADVERTISE_URL: https://plex.turbo.ac:443,http://192.168.42.128:32400,http://plex.default.svc.cluster.local:32400
+              PLEX_ADVERTISE_URL: https://plex.turbo.ac:443,http://192.168.69.128:32400,http://plex.default.svc.cluster.local:32400
               PLEX_NO_AUTH_NETWORKS: 192.168.10.0/24
             probes:
               liveness: &probes
@@ -69,7 +69,7 @@ spec:
       app:
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.42.128
+          lbipam.cilium.io/ips: 192.168.69.128
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      enabled: true
+      enabled: false
     loadBalancer:
       algorithm: maglev
       mode: dsr

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -7,20 +7,7 @@ metadata:
 spec:
   allowFirstLastIPs: "No"
   blocks:
-    - cidr: 192.168.42.0/24
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumL2AnnouncementPolicy
-metadata:
-  name: l2-policy
-spec:
-  loadBalancerIPs: true
-  interfaces:
-    - bond0
-  nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
+    - cidr: 192.168.69.0/24
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpadvertisement_v2.json
 apiVersion: cilium.io/v2
@@ -77,7 +64,7 @@ metadata:
   name: kube-api
   annotations:
     external-dns.alpha.kubernetes.io/hostname: k8s.turbo.ac
-    lbipam.cilium.io/ips: 192.168.42.120
+    lbipam.cilium.io/ips: 192.168.69.120
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -55,7 +55,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.42.126
+      lbipam.cilium.io/ips: 192.168.69.126
   listeners:
     - name: http
       protocol: HTTP
@@ -86,7 +86,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.42.121
+      lbipam.cilium.io/ips: 192.168.69.121
   listeners:
     - name: http
       protocol: HTTP

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -6,10 +6,6 @@ machine:
     {% if ENV.IS_CONTROLLER %}
     key: op://kubernetes/talos/MACHINE_CA_KEY
     {% endif %}
-  certSANs:
-    - 127.0.0.1
-    - 192.168.42.120
-    - k8s.internal
   features:
     apidCheckExtKeyUsage: true
     diskQuotaSupport: true
@@ -143,8 +139,6 @@ cluster:
       rules:
         - level: Metadata
     certSANs:
-      - 127.0.0.1
-      - 192.168.42.120
       - k8s.internal
     disablePodSecurityPolicy: true
     extraArgs:


### PR DESCRIPTION
This changes my L3 LBIPs to use a dedicated VLAN I set up in Unifi.

Apparently this should allow my nas to communicate with my cluster without using L2, we will see...

Post merge:
- Update port forwarding on router for go2rtc
- Update any hard coded old LB IPs in apps to the new LB IP.