### PR TITLE
Add a DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,6 @@ _... managed with Flux, Renovate, and GitHub Actions_ <img src="https://fonts.gs
 
 </div>
 
-
-<div align="center">
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/onedr0p/home-ops)
-
-</div>
-
 ---
 
 ## <img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f4a1/512.gif" alt="💡" width="20" height="20"> Overview
@@ -172,3 +165,11 @@ In my cluster there are two instances of [ExternalDNS](https://github.com/kubern
 ## <img src="https://fonts.gstatic.com/s/e/notoemoji/latest/1f64f/512.gif" alt="🙏" width="20" height="20"> Gratitude and Thanks
 
 Thanks to all the people who donate their time to the [Home Operations](https://discord.gg/home-operations) Discord community. Be sure to check out [kubesearch.dev](https://kubesearch.dev/) for ideas on how to deploy applications or get ideas on what you could deploy.
+
+---
+
+<div align="center">
+
+[![DeepWiki](https://img.shields.io/badge/deepwiki-purple?label=&logo=deepl&style=for-the-badge&logoColor=white)](https://deepwiki.com/onedr0p/home-ops)
+
+</div>


### PR DESCRIPTION
This adds a link to the [DeepWiki](https://deepwiki.com/onedr0p/home-ops) page for the repository, which is very helpful for a new user to learn how everything works. It also indexes the repo with DeepWiki so that the wiki automatically updates weekly. 