### PR TITLE
Removed unused values in external-secrets

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -15,10 +15,5 @@ spec:
       enabled: true
     grafanaDashboard:
       enabled: true
-    certController:
-      serviceMonitor:
-        enabled: true
     webhook:
       replicaCount: 2
-      serviceMonitor:
-        enabled: true


### PR DESCRIPTION
Not sure why it's there, I couldn't find the history in charts that has these values in the first place.
AFAIK from reading at the charts template, it looks like all of those `ServiceMonitor`s will get deployed if `serviceMonitor.enabled` value is `true`.