### PR TITLE
chore: remove post render from bbe-vpn

### DIFF
--- a/kubernetes/apps/o11y/blackbox-exporter/vpn/helmrelease.yaml
+++ b/kubernetes/apps/o11y/blackbox-exporter/vpn/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
     fullnameOverride: blackbox-exporter-vpn
     strategy:
       type: Recreate
+      rollingUpdate: null
     podAnnotations:
       k8s.v1.cni.cncf.io/networks: |-
         [{
@@ -58,12 +59,3 @@ spec:
           annotations:
             summary: |-
               The probe targeting {{ $labels.instance }} is currently having connectivity issues
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: blackbox-exporter-vpn
-            patch: |-
-              - op: remove
-                path: /spec/strategy/rollingUpdate


### PR DESCRIPTION
Removed postRenderers section for blackbox-exporter-vpn.