### PR TITLE
feat: add yayamlls workspace config

### DIFF
--- a/.yayamlls.yaml
+++ b/.yayamlls.yaml
@@ -1,0 +1,10 @@
+# yayamlls workspace config — https://github.com/home-operations/yayamlls
+#
+# Kubernetes apiVersion+kind schema auto-detect and the schemastore catalog are
+# enabled by default, so the only thing worth setting here is the Flux renderer:
+# flate renders HelmReleases and Kustomizations inline (code lens + diagnostics)
+# by following Flux source references from the cluster root.
+renderers:
+  flate:
+    enabled: true
+    path: kubernetes


### PR DESCRIPTION
Adds a `.yayamlls.yaml` at the repo root for [yayamlls](https://github.com/home-operations/yayamlls), a YAML language server with Kubernetes/Flux awareness.

It's editor-agnostic and read only by yayamlls, so it doesn't affect the existing `redhat.vscode-yaml` setup in `.vscode/`. Anyone running yayamlls against this repo gets:

- **Kubernetes schema auto-detect** and the **schemastore catalog** — both on by default, so nothing to configure.
- **Flux rendering** via the built-in `flate` renderer, scoped to the `kubernetes` cluster root so a `HelmRelease`/`Kustomization` resolves its sources (e.g. an `OCIRepository` defined elsewhere) and renders inline as a code lens with diagnostics.

```yaml
renderers:
  flate:
    enabled: true
    path: kubernetes
```

No-op for anyone not using yayamlls.