### PR TITLE
feat(kopiur): migrate repository backend to SFTP

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -10,14 +10,6 @@ spec:
     name: kopiur
   interval: 1h
   values:
-    extraVolumes:
-      - name: repo
-        nfs:
-          server: expanse.internal
-          path: /mnt/ceres/Kopiur
-    extraVolumeMounts:
-      - name: repo
-        mountPath: /repo
     monitoring:
       dashboards:
         enabled: true

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -9,14 +9,14 @@ spec:
     all: true
   backend:
     sftp:
-      host: expanse.internal
-      port: 22
-      path: /mnt/ceres/Kopiur
-      username: backup
       auth:
         secretRef:
           name: kopiur-repository-secret
           namespace: kopiur-system
+      host: expanse.internal
+      path: /mnt/ceres/Kopiur
+      port: 22
+      username: devin
   encryption:
     passwordSecretRef:
       name: kopiur-repository-secret

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -8,15 +8,18 @@ spec:
   allowedNamespaces:
     all: true
   backend:
-    filesystem:
-      path: /repo
-      volume:
-        nfs:
-          server: expanse.internal
-          path: /mnt/ceres/Kopiur
+    sftp:
+      host: expanse.internal
+      port: 22
+      path: /mnt/ceres/Kopiur
+      username: backup
+      auth:
+        secretRef:
+          name: kopiur-repository-secret
+          namespace: kopiur-system
   encryption:
     passwordSecretRef:
-      name: kopiur-nas-secret
+      name: kopiur-repository-secret
       namespace: kopiur-system
       key: KOPIA_PASSWORD
   moverDefaults:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -15,7 +15,6 @@ spec:
           namespace: kopiur-system
       host: expanse.internal
       path: /mnt/ceres/Kopiur
-      port: 22
       username: devin
   encryption:
     passwordSecretRef:

--- a/kubernetes/components/kopiur/secret/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secret/externalsecret.yaml
@@ -3,16 +3,18 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: kopiur-nas
+  name: kopiur-repository
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: kopiur-nas-secret
+    name: kopiur-repository-secret
     template:
       data:
         KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        KOPIA_SFTP_KEY_DATA: "{{ .KOPIA_SFTP_KEY_DATA }}"
+        KOPIA_SFTP_KNOWN_HOSTS: "{{ .KOPIA_SFTP_KNOWN_HOSTS }}"
   dataFrom:
     - extract:
         key: kopiur


### PR DESCRIPTION
## Overview

**Alternative to #11239** (Garage S3) — same goal (get off the NFS `filesystem` backend and its in-cluster mount), different backend. Point the `nas` ClusterRepository at the NAS over **SFTP**. The repo is reached over SSH, so like the S3 branch this drops the controller's `extraVolumes` NFS mount — but with no object-store service to run.

- **ClusterRepository** — `backend.filesystem` → `backend.sftp`: `host: expanse.internal`, `path: /mnt/ceres/Kopiur`, `username: backup`, `auth.secretRef` → `kopiur-repository-secret`. Because it targets the **same** `/mnt/ceres/Kopiur` the filesystem backend used, kopiur connects to the existing repo rather than bootstrapping a fresh one — so unlike #11239, current snapshots carry over.
- **ExternalSecret** — distribute `KOPIA_SFTP_KEY_DATA` (OpenSSH private key) and `KOPIA_SFTP_KNOWN_HOSTS` (NAS host-key line) alongside `KOPIA_PASSWORD`, all from the 1Password `kopiur` item. Secret renamed `kopiur-nas-secret` → `kopiur-repository-secret` to match #11239.
- **HelmRelease** — drop the controller's `extraVolumes`/`extraVolumeMounts`.

## Prerequisites (SFTP-only setup)

Unlike S3's access/secret keys, SFTP needs SSH plumbing on the NAS before this reconciles:

- An SSH user (`backup` above) on TrueNAS with rw to `/mnt/ceres/Kopiur`, SSH service enabled.
- A keypair: private key → 1Password `KOPIA_SFTP_KEY_DATA`; public key → that user's `authorized_keys`.
- The NAS host key captured (`ssh-keyscan expanse.internal`) into `KOPIA_SFTP_KNOWN_HOSTS` — re-capture if the box is reinstalled or connections hard-fail on host-key mismatch.

## Notes

Validated against kopiur `0.7.0` CRDs — `flux build` of `kopiur` and `kopiur-repository` renders clean; kubeconform reports ClusterRepository / HelmRelease / ExternalSecret all valid. Only `host` + `path` are schema-required on the SFTP backend.

Merge this **or** #11239, not both.

AI usage disclosure:
