### PR TITLE
feat(miroir): upgrade to 0.3.0 with diskless tie-breaker HA

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -12,6 +12,10 @@ spec:
   values:
     controller:
       autoTieBreaker: true
+    drbd:
+      resync:
+        discardGranularity: "65536"
+      verifyAlg: crc32c
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -34,7 +34,3 @@ spec:
       name: miroir-replicated
       isDefault: false
       quorum: freeze
-    storageClass:
-      create: true
-      name: miroir-local
-      isDefault: false

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: miroir
   interval: 1h
   values:
+    controller:
+      autoTieBreaker: true
     monitoring:
       serviceMonitor:
         enabled: true
@@ -27,6 +29,7 @@ spec:
       create: true
       name: miroir-replicated
       isDefault: false
+      quorum: freeze
     storageClass:
       create: true
       name: miroir-local

--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.11
+    tag: 0.3.0
   url: oci://ghcr.io/home-operations/charts/miroir


### PR DESCRIPTION
## Overview

Upgrade miroir `0.2.11` → `0.3.0` and turn on **proper HA for replicated volumes via the new diskless tie-breaker**, on the same Corsair disks. 0.3.0 adds ([#70](https://github.com/home-operations/miroir/issues/70), [#81](https://github.com/home-operations/miroir/issues/81)):

- **`controller.autoTieBreaker`** (default true) — for a 2-replica `freeze` volume, the controller places a third peer on the spare node as a **diskless tie-breaker**: a DRBD peer rendered `disk none` that votes in quorum but stores nothing. Result: 2 diskful legs + 1 diskless vote → losing any single node (a data leg *or* the tie-breaker) still leaves majority quorum. No split-brain, no third data copy.
- **`quorum: freeze`** is the new default (was `last-man-standing`) — majority quorum with `on-no-quorum io-error` instead of last-man-standing.

Only breaking change in 0.3.0 is CI-internal. The `nodes`/`lvmthin` backend is unchanged — same disks, same pools.

## Changes

- `ocirepository.yaml` — `tag: 0.2.11` → `0.3.0`.
- `helmrelease.yaml` — set `controller.autoTieBreaker: true` and `replicatedStorageClass.quorum: freeze` explicitly (both are 0.3.0 defaults; pinned here to document the HA intent). `serviceMonitor` stays enabled.
- `helmrelease.yaml` — two of 0.3.0's new DRBD knobs, matched to the all-`lvmthin`-on-NVMe layout:
  - `drbd.resync.discardGranularity: "65536"` — full resyncs send runs of zeroes as discards, keeping a re-added thin leg thin (and sparing the DRAM-less MP600 MICROs pointless zero-writes).
  - `drbd.verifyAlg: crc32c` — makes `drbdadm verify` available (the only cross-leg integrity check); run it manually/cron in quiet hours, out-of-sync blocks surface in the kernel log.
  - Resync rate knobs (`planAhead`/`maxRate`/…) deliberately left default: the replicated footprint is tiny and DRBD shares the 10GbE bond with Ceph — an aggressive ceiling would just contend with OSD traffic.

## Do the disks/pools need reprovisioning? **No.**

You floated destroying miroir and rebuilding the pools — not needed:

- **Pools are reused on upgrade** — the agent re-runs pool provisioning and reuses the existing thin pool on `/dev/disk/by-partlabel/r-miroir`. No `talosctl wipe`, no partition changes.
- **The tie-breaker is diskless** — it needs no backing device on its node, so nothing new to provision.
- **Existing volumes are retrofitted** — flipping a volume to `freeze` (or the controller restart on upgrade) appends a tie-breaker to every 2-replica `freeze` volume that lacks one.

## Migration (the one real step: the quorum switch)

`StorageClass.parameters` is **immutable**, so changing the `miroir-replicated` quorum from `last-man-standing` → `freeze` means the StorageClass must be recreated, and existing replicated volumes recreated to pick up `freeze` + the tie-breaker. The only replicated volume today is kopiur's mover cache — disposable — so this is cheap.

1. **Merge this PR.** Flux upgrades the chart to 0.3.0.
2. **Recreate the StorageClass** (Helm can't patch the immutable quorum param, so the HR upgrade will flag it):
   ```sh
   kubectl delete storageclass miroir-replicated
   flux reconcile helmrelease -n miroir-system miroir
   # recreated with parameters.quorum=freeze; deleting an SC does not touch bound PVs
   ```
3. **Recreate existing `miroir-replicated` volumes** so they re-provision under `freeze` and get a tie-breaker (kopiur re-creates its cache on the next mover run):
   ```sh
   kubectl get pvc -A -o json \
     | jq -r '.items[] | select(.spec.storageClassName=="miroir-replicated") | "\(.metadata.namespace) \(.metadata.name)"' \
     | while read -r ns name; do kubectl -n "$ns" delete pvc "$name"; done
   ```
   (For a *non-disposable* replicated volume you'd instead edit its `MiroirVolume` `spec.quorumPolicy` `last-man-standing`→`freeze` to retrofit in place without recreating the PVC.)
4. **Verify HA:** provision/observe a `miroir-replicated` volume and confirm it has **3 peers — 2 diskful + 1 diskless** and `quorum: freeze`:
   ```sh
   kubectl get storageclass miroir-replicated -o jsonpath='{.parameters}' ; echo
   kubectl get miroirvolumes -A          # 2 diskful legs + 1 diskless tie-breaker per replicated volume
   ```

## Optional — clean reprovision (only if you want a pristine pool)

Not required, but if you'd rather start fresh: scale down consumers → delete `miroir-replicated` PVCs → `kubectl -n miroir-system delete hr miroir` (or suspend) → optionally wipe each node's thin pool on `r-miroir` (`talosctl -n <node> wipe disk nvme1n1p1 --drop-partition`, then Talos re-lays `r-miroir`) → re-merge → agents bootstrap fresh pools → recreate PVCs. Since the only data is the disposable cache, the in-place path above is strictly simpler.

## Validation

`flux build` of the miroir app renders clean and kubeconform is green; rendered values show `tag: 0.3.0`, `autoTieBreaker: true`, `quorum: freeze`, `serviceMonitor` enabled.

## Requirements

- AI usage disclosure:
