### PR TITLE
feat(container): update image ghcr.io/home-operations/charts/miroir (0.7.0 ➔ 0.8.0)

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.7.0
+    tag: 0.8.0
   url: oci://ghcr.io/home-operations/charts/miroir


### PR DESCRIPTION
Bumps the miroir chart/app from 0.7.0 to 0.8.0.

[Release notes](https://github.com/home-operations/miroir/releases/tag/0.8.0)

### Breaking change

Agents now enforce a DRBD kernel module floor of 9.3.1 at startup (home-operations/miroir#198). Verified on this cluster: all three nodes run Talos v1.13.6 with DRBD module 9.3.2, so the floor is satisfied.

### Notable changes

- Client (diskless) legs are excluded from quorum voting (home-operations/miroir#199)
- Real discard granularity advertised on client legs (home-operations/miroir#201)
- New per-StorageClass `bitmapGranularity` knob for DRBD bitmap block size (home-operations/miroir#200) - not set here; the 4k default is appropriate for current volume sizes

No values changes required; only the OCIRepository tag is bumped.