### PR TITLE
feat(container)!: update image ghcr.io/home-operations/charts/miroir (0.9.0 ➔ 0.10.0)

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -24,14 +24,20 @@ spec:
         enabled: true
     nodes:
       k8s-0:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
+        pools:
+          default:
+            backend: lvmthin
+            device: /dev/disk/by-partlabel/r-miroir
       k8s-1:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
+        pools:
+          default:
+            backend: lvmthin
+            device: /dev/disk/by-partlabel/r-miroir
       k8s-2:
-        backend: lvmthin
-        device: /dev/disk/by-partlabel/r-miroir
+        pools:
+          default:
+            backend: lvmthin
+            device: /dev/disk/by-partlabel/r-miroir
     storageClasses:
       - name: miroir-local
         isDefault: false
@@ -41,4 +47,3 @@ spec:
         replicas: 2
     volumeSnapshotClasses:
       - name: miroir-snap
-

--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.9.0
+    tag: 0.10.0
   url: oci://ghcr.io/home-operations/charts/miroir


### PR DESCRIPTION
Bumps miroir from 0.9.0 to 0.10.0 and applies the breaking-change migration from [home-operations/miroir#210](https://github.com/home-operations/miroir/pull/210): storage is re-keyed from `node` to `(node, pool)`, so each node's storage config must now be nested under a named pool. The existing single pool is adopted as the pool named `default`.

## Changes

- `ocirepository.yaml`: chart tag `0.9.0` ➔ `0.10.0`
- `helmrelease.yaml`: each node's `backend`/`device` moved under `pools.default` per the migration guide

No pool reference is needed on the existing StorageClasses or MiroirVolumes; an empty pool resolves to `default`, so existing volumes are adopted as-is with no data migration or downtime.

Verified `helm template` succeeds against chart 0.10.0 with the migrated values (the chart fails fast on the old flat shape).