### PR TITLE
feat(miroir): upgrade to 0.11.0 with CR-based storage topology

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -11,6 +11,13 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
+    drbd:
+      # DRBD's default activity-log size amplifies scattered random writes
+      # (kopia caches) on consumer NVMe; larger AL trades longer post-crash
+      # resync for less metadata churn
+      alExtents: 6007
+      verify:
+        schedule: "0 5 * * 1"
     monitoring:
       dashboards:
         enabled: true

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -11,15 +11,9 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
-    # keep well above any node reboot or upgrade window
     autoEvictAfter: 2h
     drbd:
-      # DRBD's default activity-log size amplifies scattered random writes
-      # (kopia caches) on consumer NVMe; larger AL trades longer post-crash
-      # resync for less metadata churn
       alExtents: 6007
-      verify:
-        schedule: "0 5 * * 1"
     monitoring:
       dashboards:
         enabled: true

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
-    autoEvictAfter: 2h
+    autoEvictAfter: 1h
     drbd:
       alExtents: 6007
     monitoring:

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
+    # keep well above any node reboot or upgrade window
+    autoEvictAfter: 2h
     drbd:
       # DRBD's default activity-log size amplifies scattered random writes
       # (kopia caches) on consumer NVMe; larger AL trades longer post-crash

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -8,11 +8,7 @@ spec:
   chartRef:
     kind: OCIRepository
     name: miroir
-  install:
-    crds: CreateReplace
   interval: 1h
-  upgrade:
-    crds: CreateReplace
   values:
     replicaCount: 2
     monitoring:

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -10,7 +10,6 @@ spec:
     name: miroir
   interval: 1h
   values:
-    replicaCount: 2
     autoEvictAfter: 1h
     drbd:
       alExtents: 6007
@@ -25,3 +24,4 @@ spec:
         enabled: true
       prometheusRule:
         enabled: true
+    replicaCount: 2

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -8,6 +8,8 @@ spec:
   chartRef:
     kind: OCIRepository
     name: miroir
+  install:
+    crds: CreateReplace
   interval: 1h
   upgrade:
     crds: CreateReplace

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -9,6 +9,8 @@ spec:
     kind: OCIRepository
     name: miroir
   interval: 1h
+  upgrade:
+    crds: CreateReplace
   values:
     replicaCount: 2
     monitoring:
@@ -22,28 +24,3 @@ spec:
         enabled: true
       prometheusRule:
         enabled: true
-    nodes:
-      k8s-0:
-        pools:
-          default:
-            backend: lvmthin
-            device: /dev/disk/by-partlabel/r-miroir
-      k8s-1:
-        pools:
-          default:
-            backend: lvmthin
-            device: /dev/disk/by-partlabel/r-miroir
-      k8s-2:
-        pools:
-          default:
-            backend: lvmthin
-            device: /dev/disk/by-partlabel/r-miroir
-    storageClasses:
-      - name: miroir-local
-        isDefault: false
-      - name: miroir-replicated
-        isDefault: false
-        quorum: freeze
-        replicas: 2
-    volumeSnapshotClasses:
-      - name: miroir-snap

--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.10.5
+    tag: 0.11.0
   url: oci://ghcr.io/home-operations/charts/miroir

--- a/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./miroirnodegroup.yaml
+  - ./storageclass.yaml
+  - ./volumesnapshotclass.yaml

--- a/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
@@ -5,7 +5,9 @@ kind: MiroirNodeGroup
 metadata:
   name: default
 spec:
-  nodeSelector: {} # every node in the cluster
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/control-plane: ""
   template:
     pools:
       - name: default

--- a/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
@@ -10,6 +10,6 @@ spec:
       node-role.kubernetes.io/control-plane: ""
   template:
     pools:
-      - name: default
+      - name: slow
         lvmthin:
           device: /dev/disk/by-partlabel/r-miroir

--- a/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/miroir.home-operations.com/miroirnodegroup_v1alpha1.json
+apiVersion: miroir.home-operations.com/v1alpha1
+kind: MiroirNodeGroup
+metadata:
+  name: default
+spec:
+  nodeSelector: {} # every node in the cluster
+  template:
+    pools:
+      - name: default
+        lvmthin:
+          device: /dev/disk/by-partlabel/r-miroir

--- a/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
@@ -12,4 +12,4 @@ spec:
     pools:
       - name: slow
         lvmthin:
-          device: /dev/disk/by-partlabel/r-miroir
+          device: /dev/disk/by-partlabel/r-miroir-slow

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/storage.k8s.io/storageclass_v1.json
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-local
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  miroir.home-operations.com/replicas: "1"
+  csi.storage.k8s.io/fstype: ext4
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/storage.k8s.io/storageclass_v1.json
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-replicated
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  miroir.home-operations.com/replicas: "2"
+  miroir.home-operations.com/quorum: freeze
+  csi.storage.k8s.io/fstype: ext4

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -8,6 +8,7 @@ provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
+  miroir.home-operations.com/pool: default
   miroir.home-operations.com/replicas: "1"
   csi.storage.k8s.io/fstype: ext4
 ---
@@ -20,6 +21,7 @@ provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
+  miroir.home-operations.com/pool: default
   miroir.home-operations.com/replicas: "2"
   miroir.home-operations.com/quorum: freeze
   csi.storage.k8s.io/fstype: ext4

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -3,12 +3,12 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-default-local
+  name: miroir-slow-local
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
-  miroir.home-operations.com/pool: default
+  miroir.home-operations.com/pool: slow
   miroir.home-operations.com/replicas: "1"
   csi.storage.k8s.io/fstype: ext4
 ---
@@ -16,12 +16,12 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-default-replicated
+  name: miroir-slow-replicated
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
-  miroir.home-operations.com/pool: default
+  miroir.home-operations.com/pool: slow
   miroir.home-operations.com/replicas: "2"
   miroir.home-operations.com/quorum: freeze
   csi.storage.k8s.io/fstype: ext4

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -16,7 +16,7 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-slow-replicated
+  name: miroir-slow
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -3,7 +3,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-local
+  name: miroir-default-local
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
@@ -16,7 +16,7 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: miroir-replicated
+  name: miroir-default-replicated
 provisioner: miroir.home-operations.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/snapshot.storage.k8s.io/volumesnapshotclass_v1.json
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: miroir-snap
+driver: miroir.home-operations.com
+deletionPolicy: Delete

--- a/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
@@ -3,6 +3,6 @@
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
-  name: miroir-snap
+  name: miroir
 driver: miroir.home-operations.com
 deletionPolicy: Delete

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -14,3 +14,21 @@ spec:
     namespace: flux-system
   targetNamespace: miroir-system
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: miroir-config
+spec:
+  dependsOn:
+    - name: miroir
+  interval: 1h
+  path: ./kubernetes/apps/miroir-system/miroir/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: miroir-system
+  wait: true

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -23,6 +23,8 @@ metadata:
 spec:
   dependsOn:
     - name: miroir
+    - name: snapshot-controller
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/miroir-system/miroir/config
   prune: true

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 metadata:
   name: miroir
 spec:
+  dependsOn:
+    - name: snapshot-controller
+      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/miroir-system/miroir/app
   prune: true
@@ -23,8 +26,6 @@ metadata:
 spec:
   dependsOn:
     - name: miroir
-    - name: snapshot-controller
-      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/miroir-system/miroir/config
   prune: true

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -11,7 +11,7 @@ spec:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       mode: Persistent
-      storageClassName: miroir-replicated
+      storageClassName: miroir-default-replicated
     securityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -11,7 +11,7 @@ spec:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       mode: Persistent
-      storageClassName: miroir-default-replicated
+      storageClassName: miroir-slow-replicated
     securityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -11,7 +11,7 @@ spec:
     cache:
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       mode: Persistent
-      storageClassName: miroir-slow-replicated
+      storageClassName: miroir-slow
     securityContext:
       runAsUser: ${KOPIUR_PUID:=1000}
       runAsGroup: ${KOPIUR_PGID:=1000}

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -220,7 +220,7 @@ mtu: 9000
 ---
 apiVersion: v1alpha1
 kind: RawVolumeConfig
-name: miroir
+name: miroir-slow
 provisioning:
   diskSelector:
     match: disk.model == "Corsair MP600 MICRO" && !system_disk


### PR DESCRIPTION
## Summary

Upgrades miroir 0.10.5 ➔ 0.11.0. This release moves the storage configuration out of the chart entirely: node topology becomes CRs, and the StorageClasses/VolumeSnapshotClasses become plain manifests ([upgrade guide](https://github.com/home-operations/miroir/blob/0.11.0/docs/upgrading.md#010x--0110-node-topology-becomes-miroirnode-crs)).

- Bump the chart OCIRepository to `0.11.0`
- Drop `nodes`, `storageClasses`, and `volumeSnapshotClasses` from the HelmRelease values (0.11.0 fails fast if any is still set); CRD handling needs no change here - `install.crds: CreateReplace` / `upgrade.crds: CreateReplace` are inherited from the cluster-apps patch, which covers the stale-CRD-on-reinstall case
- New `miroir-config` Flux Kustomization (`dependsOn: miroir`) under `miroir/config` holding:
  - A `MiroirNodeGroup` selecting control-plane nodes, templating the `slow` lvmthin pool (consumer NVMe tier, vs the enterprise NVMe rook pool) on `/dev/disk/by-partlabel/r-miroir-slow`
  - `miroir-slow` (replicated, the unsuffixed default) / `miroir-slow-local` StorageClasses (pool-scoped names, so a future second pool gets its own `miroir-<pool>-*` classes without collisions) with the previously chart-defaulted fields written explicitly (`volumeBindingMode: WaitForFirstConsumer`, `allowVolumeExpansion: true`) and the old knobs mapped to parameters (`pool`, `replicas`, `quorum: freeze`, `fstype: ext4`)
  - The `miroir` VolumeSnapshotClass
- Point the kopiur backup component's SnapshotPolicy cache at the renamed `miroir-slow` class
- Rename the Talos `RawVolumeConfig` from `miroir` to `miroir-slow`, so the partition label becomes `r-miroir-slow` to match the pool (the node group's `device` follows suit)
- Consumer-NVMe tuning for the 0.11.0 DRBD knobs: weekly scheduled online verify (`drbd.verify.schedule`, cross-leg integrity check using the default crc32c) and a larger activity log (`drbd.alExtents: 6007`) to cut metadata write amplification under scattered random writes
- `autoEvictAfter: 1h` - re-place a dead node's replica legs after its heartbeat has been stale 1h (above any reboot/upgrade window); with 3 nodes and 2 replicas there is always a spare node carrying the `slow` pool

## Redeploy plan

Not following the in-place migration path. All miroir-replicated PVCs are kopiur caches (19x `kopiur-cache-*` in `default`, re-created by kopiur on demand); nothing uses `miroir-local`, and there are no VolumeSnapshots. So: tear down, wipe, redeploy fresh.

**Steps 1-4 must be completed BEFORE merging this PR.** Once merged, `cluster-apps` reconciles within the hour and would upgrade miroir in place against the old topology and a partlabel that does not exist yet - the suspends in step 1 are what make the merge safe.

### 1. Suspend Flux and scale down kopiur (pre-merge)

```sh
flux suspend kustomization miroir -n miroir-system
flux suspend kustomization kopiur -n kopiur-system
kubectl -n kopiur-system scale deploy kopiur-controller --replicas=0
```

`kopiur-webhook` must STAY running: the `kopiur-validating` webhook has `failurePolicy: Fail` on SnapshotPolicy create/update, and merging this PR updates every app's SnapshotPolicy (cache class rename) - with the webhook down, every app Kustomization in `default` would fail to apply. Only the controller stops. The cache PVCs carry no kopiur finalizer (only `pvc-protection`, owner ref has `blockOwnerDeletion: false`), so step 2's deletions complete with the controller down.

Wait for any in-flight backup pods still mounting the caches to finish:

```sh
kubectl get pods -A | rg kopiur
```

### 2. Delete the miroir-replicated PVCs (pre-merge, while miroir is still running so the CSI driver cleans up the volumes)

```sh
kubectl -n default get pvc -o name | rg kopiur-cache | xargs kubectl -n default delete
```

Confirm the volumes are gone before moving on:

```sh
kubectl get miroirvolumes
kubectl get pv | rg miroir
```

### 3. Uninstall miroir and drop the stale 0.10 CRDs (pre-merge)

The 0.10.5 pre-delete hook removes any remaining MiroirVolume/MiroirSnapshot objects; the CRDs survive `helm uninstall`, so delete them explicitly (this also removes the agent-created MiroirNode objects with the old schema):

```sh
kubectl -n miroir-system delete helmrelease miroir
kubectl -n miroir-system get pods   # wait for empty
kubectl delete crd miroirnodes.miroir.home-operations.com miroirsnapshots.miroir.home-operations.com miroirvolumes.miroir.home-operations.com
```

### 4. Rename the raw volume and re-provision the partitions (pre-merge)

First apply the updated machine config from this branch (it renders from the local working tree). Talos never destroys data on a config change: the old `r-miroir` partition stays put, and the renamed `miroir-slow` raw volume sits pending because the disk has no free space yet.

```sh
just talos apply-node 192.168.42.10
just talos apply-node 192.168.42.11
just talos apply-node 192.168.42.12
```

The apply must come first: the wipe API refuses a partition that backs an active volume (`FailedPrecondition: in use by volume`), and dropping the old `RawVolumeConfig` is what releases it. Then wipe **with** `--drop-partition` - deleting the partition frees the space and Talos immediately provisions the new `r-miroir-slow` partition into it. Device names verified via `talosctl get discoveredvolumes` - note k8s-1 differs:

```sh
talosctl -n 192.168.42.10 wipe disk nvme0n1p1 --drop-partition   # k8s-0
talosctl -n 192.168.42.11 wipe disk nvme1n1p1 --drop-partition   # k8s-1
talosctl -n 192.168.42.12 wipe disk nvme0n1p1 --drop-partition   # k8s-2
```

If the wipe is refused with `in use by blockdevice "dm-0"`, the old `vg-miroir` thin-pool stack is still active in device-mapper (uninstalling miroir does not deactivate it, and a reboot does not help - Talos re-activates discovered LVM2 PVs at boot). Deactivate the VG from a privileged pod pinned to that node, then retry the wipe:

```sh
kubectl run vg-deactivate --rm -i --restart=Never -n kube-system --image=alpine:3.22 --overrides='{"spec":{"nodeName":"<node>","containers":[{"name":"vg-deactivate","image":"alpine:3.22","command":["sh","-c","apk add --no-cache lvm2 >/dev/null 2>&1 && vgchange -an vg-miroir --config \"activation{udev_sync=0 udev_rules=0}\""],"securityContext":{"privileged":true},"volumeMounts":[{"name":"dev","mountPath":"/dev"}]}],"volumes":[{"name":"dev","hostPath":{"path":"/dev"}}]}}'
```

Confirm the new partlabel exists on all three nodes before moving on:

```sh
talosctl -n 192.168.42.10,192.168.42.11,192.168.42.12 get discoveredvolumes | rg r-miroir-slow
```

### 5. Merge this PR and redeploy

```sh
flux reconcile source git flux-system -n flux-system
flux reconcile kustomization cluster-apps -n flux-system   # creates the new miroir-config Kustomization
flux resume kustomization miroir -n miroir-system
```

`miroir` reinstalls the driver at 0.11.0 (CRDs via the inherited `install.crds: CreateReplace`), then `miroir-config` applies the MiroirNodeGroup and classes. Each agent provisions its pool from the wiped partition at startup.

### 6. Verify, then bring kopiur back

```sh
kubectl get miroirnodegroups,miroirnodes
kubectl get miroirnode k8s-0 -o yaml   # spec.pools should show the lvmthin block
kubectl get storageclass miroir-slow miroir-slow-local
```

```sh
flux resume kustomization kopiur -n kopiur-system
kubectl -n kopiur-system scale deploy kopiur-controller --replicas=1
```

Kopiur re-provisions its `kopiur-cache-*` PVCs on the next backup runs.








