### PR TITLE
chore: migrate multus to home-operations helm chart

### DIFF
--- a/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/multus/app/helmrelease.yaml
@@ -10,12 +10,8 @@ spec:
     name: multus
   interval: 1h
   values:
-    cni:
-      binPath: /opt/cni/bin
-      netPath: /etc/cni/net.d
-    multus:
-      resources:
-        requests:
-          cpu: 10m
-        limits:
-          memory: 512Mi
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/multus/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.3.2
-  url: oci://ghcr.io/bjw-s-labs/helm/multus
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/multus


### PR DESCRIPTION
Migrates the multus HelmRelease from the bjw-s-labs chart (1.3.2) to the [home-operations/helm-charts](https://github.com/home-operations/helm-charts) multus chart (0.1.0), following the same pattern as the snapshot-controller migration (#11323).

- OCIRepository now points at `oci://ghcr.io/home-operations/charts/multus` tag `0.1.0`
- `multus.resources` moves to top-level `resources` in the new chart's values
- Dropped explicit `cni.binPath`/`cni.netPath`; the new chart's `cni.binDir`/`cni.netDir` defaults are identical (`/opt/cni/bin`, `/etc/cni/net.d`)
- Verified with `helm template`: resources land on the DaemonSet container and the `network-attachment-definitions.k8s.cni.cncf.io` CRD still ships, so the existing Kustomization healthChecks remain valid