### PR TITLE
feat: add shared home-operations label to the runner for pooling

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -14,6 +14,7 @@ spec:
     githubConfigSecret: home-operations-runner-secret
     runnerScaleSetName: home-operations-onedr0p
     runnerGroup: home-operations
+    scaleSetLabels: ["home-operations"]
     minRunners: 3
     maxRunners: 3
     containerMode:


### PR DESCRIPTION
## What

Adds `scaleSetLabels: ["home-operations"]` to the `home-operations-runner` HelmRelease (renders to `spec.runnerScaleSetLabels` on the AutoscalingRunnerSet).

## Why

ARC 0.14 (chart 0.14.2, already deployed) added multi-label support for runner scale sets. Assigning a shared **label** - rather than the unique scale-set **name** - lets other org admins deploy their own scale set in the `home-operations` group with the same `home-operations` label, so workflows using `runs-on: home-operations` route across the whole pool. `runs-on` can't target a runner group directly; a shared label is the pooling mechanism.

The scale set keeps its unique name `home-operations-onedr0p` (names must be unique within a group), so `runs-on: home-operations-onedr0p` still works too - the label is additive.

## Notes

- This only *enables* pooling on this side; a second admin still has to deploy their own scale set with `scaleSetLabels: ["home-operations"]` + `runnerGroup: home-operations` for anything to join.
- Companion: home-operations/miroir#302 switches the e2e QEMU legs to `runs-on: home-operations`.
- Exact load-balancing across two scale sets sharing a label is the documented "routing flexibility" use, but worth confirming by test once a second scale set exists.

## Validation

- `kustomize build` clean; `oxfmt` clean.
- `helm template` (chart 0.14.2) confirms `scaleSetLabels: [home-operations]` → `spec.runnerScaleSetLabels: [home-operations]`.
