### PR TITLE
revert: drop the dead home-operations scale-set label

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -14,7 +14,6 @@ spec:
     githubConfigSecret: home-operations-runner-secret
     runnerScaleSetName: home-operations-onedr0p
     runnerGroup: home-operations
-    scaleSetLabels: ["home-operations"]
     minRunners: 3
     maxRunners: 3
     containerMode:


### PR DESCRIPTION
## What

Removes `scaleSetLabels: ["home-operations"]` from the `home-operations-runner` HelmRelease (added in #11329).

## Why

Custom runner scale-set labels are a **GitHub Enterprise Server-only** feature (3.18+ behind `DistributedTask.AllowRunnerScaleSetCustomLabels`); on **github.com** they don't register with the API. So the label never appeared on the org runners page and `runs-on: home-operations` matched nothing (jobs piled up in "available jobs"). See [actions/scaleset](https://github.com/actions/scaleset#github-enterprise-server) and [ARC#4425](https://github.com/actions/actions-runner-controller/issues/4425).

On github.com, scale sets are targeted by **name** only, so pooling multiple admins' separate scale sets under one `runs-on` isn't possible. Going with **Option C**: each admin runs a uniquely-named scale set (`home-operations-onedr0p`, `home-operations-<buddy>`) and workflows target names / matrix.

Companion: home-operations/miroir#302 targets `runs-on: home-operations-onedr0p`.

## Validation

- `kustomize build` clean; `oxfmt` clean.
- The scale set keeps working by name (`home-operations-onedr0p`); this only removes inert config.