### PR TITLE
feat: run the home-operations runner in dind mode

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -17,14 +17,7 @@ spec:
     minRunners: 3
     maxRunners: 3
     containerMode:
-      type: kubernetes
-      kubernetesModeWorkVolumeClaim:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: ceph-block
-        resources:
-          requests:
-            storage: 10Gi
+      type: dind
     controllerServiceAccount:
       name: actions-runner-controller
       namespace: actions-runner-system


### PR DESCRIPTION
## What

Switches the `home-operations-runner` from `containerMode: kubernetes` to `containerMode: dind`.

## Why

The runner (kubernetes mode) has no Docker daemon, so Docker-heavy jobs fail - e.g. miroir's Talos QEMU e2e fails at `docker run ... registry:3` (home-operations/miroir#302). `dind` mode adds a Docker-in-Docker sidecar so `docker`/buildx work. Same runner image; the existing kubernetes-mode runner is unchanged (its CI needs no Docker).

## Tradeoff

The `dind` sidecar is **privileged** - this reverses the non-privileged property from #11326. KVM stays non-privileged via the device plugin; only the dind sidecar is privileged. Accepted to run the org's virtualization + Docker e2e on-cluster.

## Details

- `helm template` (chart 0.14.2) confirms: privileged `docker:dind` sidecar + `init-dind-externals`, and the `runner` container keeps `devices.kubevirt.io/kvm: 1` and gains `DOCKER_HOST`. Work dir becomes an emptyDir (the ceph-block PVC of kube mode is dropped).
- Namespace `actions-runner-system` has no restrictive PSA labels, so the privileged sidecar is admitted.

## Validation

- `kustomize build` clean; `oxfmt` clean.
- Re-tests home-operations/miroir#302 once deployed.