### PR TITLE
feat: make the home-operations runner container privileged

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -41,6 +41,8 @@ spec:
             env:
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
+            securityContext:
+              privileged: true
             resources:
               limits:
                 devices.kubevirt.io/kvm: 1


### PR DESCRIPTION
## What

Adds `securityContext.privileged: true` to the `home-operations-runner` container (on top of the already-privileged dind sidecar from #11331).

## Why

miroir's Talos QEMU e2e (home-operations/miroir#302) boots real Talos clusters under QEMU via `sudo talosctl ... qemu`, which creates bridge/TAP interfaces and iptables NAT. That needs a privileged runner container - with dind alone it fails at `Create cluster` (bridge/tun/iptables). This is **Option B**: full privilege to verify the workload runs on-cluster.

## Tradeoff / follow-up

The whole runner pod is now privileged, reversing the non-privileged goal of #11326. Tracked for a **Kata Containers** (Talos sysext) approach that keeps the isolation in a VM boundary instead: #11332.

Note: miroir#302 also needs `iptables` installed in the QEMU legs (added there) - the runner image doesn't ship it.

## Validation

- `kustomize build` clean; `oxfmt` clean. Re-tests miroir#302 once deployed.