### PR TITLE
feat(talos): add kata-containers system extension

### DIFF
--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -13,6 +13,7 @@ customization:
       - siderolabs/drbd # Miroir DRBD9 Replication
       - siderolabs/i915 # Intel iGPU
       - siderolabs/intel-ucode # Intel iGPU
+      - siderolabs/kata-containers # Kata Containers runtime (CI microVMs, #11332)
       - siderolabs/mei # Intel iGPU
       - siderolabs/thunderbolt # Thunderbolt NICs
       - siderolabs/xe # Intel iGPU

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -13,7 +13,7 @@ customization:
       - siderolabs/drbd # Miroir DRBD9 Replication
       - siderolabs/i915 # Intel iGPU
       - siderolabs/intel-ucode # Intel iGPU
-      - siderolabs/kata-containers
+      - siderolabs/kata-containers # Home Operations Org Runners
       - siderolabs/mei # Intel iGPU
       - siderolabs/thunderbolt # Thunderbolt NICs
       - siderolabs/xe # Intel iGPU

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -13,7 +13,7 @@ customization:
       - siderolabs/drbd # Miroir DRBD9 Replication
       - siderolabs/i915 # Intel iGPU
       - siderolabs/intel-ucode # Intel iGPU
-      - siderolabs/kata-containers # Kata Containers runtime (CI microVMs, #11332)
+      - siderolabs/kata-containers
       - siderolabs/mei # Intel iGPU
       - siderolabs/thunderbolt # Thunderbolt NICs
       - siderolabs/xe # Intel iGPU


### PR DESCRIPTION
## What

Adds the **`siderolabs/kata-containers`** system extension to the Talos schematic (`talos/schematic.yaml.j2`).

## Why

So CI virtualization workloads (miroir's Talos-QEMU e2e, home-operations/miroir#302) can run under a **Kata `RuntimeClass`** - VM-isolated - instead of the current **privileged** runner pod (dind sidecar #11331 + privileged runner container). Tracks toward dropping that privilege. See #11332.

## Effect on the schematic

Adding the extension changes the schematic ID and therefore the installer image:

- **Schematic ID:** `1500dcc8c3a4b6b897762a22fe5bb0011ca3f5d35687fa995b95b129910b2545`
- **Installer image:** `factory.talos.dev/metal-installer/1500dcc8c3a4b6b897762a22fe5bb0011ca3f5d35687fa995b95b129910b2545:v1.13.6`

(Preview locally with `just talos schematic-id` / `just talos machine-image`.)

## Apply + upgrade (after merge)

The extension only lands once each node is upgraded into the new installer image. Do it **one node at a time**, waiting for `Ready` before the next.

```sh
# 1) Apply the updated machine config so install.image tracks the new schematic
just talos apply-node k8s-0
just talos apply-node k8s-1
just talos apply-node k8s-2

# 2) Upgrade each node into the new schematic image (adds the kata extension); powercycles the node
just talos upgrade-node k8s-0
just talos upgrade-node k8s-1
just talos upgrade-node k8s-2
```

## Verify

```sh
# extension present on the node
talosctl -n k8s-0 get extensions | grep -i kata
# after the RuntimeClass exists (below), a smoke test
kubectl run kata-test --rm -it --restart=Never \
  --overrides='{"spec":{"runtimeClassName":"kata"}}' --image=busybox -- uname -a
```

## Remaining wiring (follow-up, #11332)

Not in this PR - do after the nodes are upgraded:

1. Create the RuntimeClass (handler `kata`):
   ```yaml
   apiVersion: node.k8s.io/v1
   kind: RuntimeClass
   metadata:
     name: kata
   handler: kata
   ```
2. Set `template.spec.runtimeClassName: kata` on the `home-operations-onedr0p` runner.
3. Drop `privileged: true` from the runner container (and reassess the dind sidecar) once Kata carries the isolation.
4. Confirm nested virt reaches the Kata guest (miroir runs QEMU *inside* the pod).
