### PR TITLE
feat(cilium): switch datapath from netkit to veth

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       enabled: true
       bbr: true
     bpf:
-      datapathMode: veth
+      datapathMode: veth # https://github.com/kata-containers/kata-containers/issues/12159
       masquerade: true
       preallocateMaps: true
     bpfClockProbe: true

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       enabled: true
       bbr: true
     bpf:
-      datapathMode: netkit
+      datapathMode: veth
       masquerade: true
       preallocateMaps: true
     bpfClockProbe: true


### PR DESCRIPTION
## What

Switches Cilium's pod datapath from **`netkit` → `veth`** (`bpf.datapathMode`). One-line change.

## Why

**Kata Containers doesn't support netkit** network interfaces - every kata pod fails at sandbox creation with `Unsupported network interface: netkit` (verified on this cluster; kata-containers#11149). netkit has no per-pod override, so unblocking Kata (for VM-isolated CI runners instead of a privileged pod - see #11332) requires moving the whole cluster to veth.

## Only this one knob changes

Confirmed against the [Cilium tuning docs](https://docs.cilium.io/en/stable/operations/performance/tuning/): netkit is **not** required by any other feature here. Everything else stays and keeps working on veth:

- **BBR** (`bandwidthManager.bbr`) - needs eBPF host-routing (present via `kubeProxyReplacement: true`), not netkit.
- **BIG TCP** (`enableIPv4BIGTCP`) - needs eBPF host-routing, not netkit.
- **bpf masquerade**, **endpoint routes** (already on, and actually recommended for Kata), **DSR** load balancing, **socketLB `hostNamespaceOnly: true`** (already set - the key Kata+kube-proxy-replacement requirement) - all datapath-agnostic.

netkit was purely a performance datapath layer; veth is the long-standing default.

## What we give up

netkit's near-host-namespace pod throughput/latency. In practice small here: Cilium's eBPF host-routing already closes most of the veth-vs-host gap, and typical homelab traffic won't notice. Fully reversible (flip back to `netkit` if Kata ever gains netkit support).

## Rollout / impact

- Cilium agents roll on the config change (`rollOutCiliumPods: true`).
- `datapathMode` applies at **pod sandbox creation** - existing pods keep their netkit devices until recreated; new pods get veth. netkit and veth pods interoperate during the transition, so it's not a hard cutover.
- To fully converge, cycle workloads (rolling restart) at your convenience. **No node reboots.**
- Recommend rolling this during a maintenance window given it touches cluster-wide networking.

## Follow-up (after this merges + settles)

Re-attempt the Kata smoke test (should get past the netkit sandbox error), validate nested virt (`/dev/kvm` inside the Kata guest for miroir's QEMU), then migrate `home-operations-onedr0p` to `runtimeClassName: kata` and drop `privileged`. Tracked in #11332.

## Validation

- `kustomize build` clean; `oxfmt` clean.
