### PR TITLE
revert(cilium): back to netkit datapath

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
       enabled: true
       bbr: true
     bpf:
-      datapathMode: veth # https://github.com/kata-containers/kata-containers/issues/12159
+      datapathMode: netkit # https://github.com/kata-containers/kata-containers/issues/12159
       masquerade: true
       preallocateMaps: true
     bpfClockProbe: true


### PR DESCRIPTION
## Reverts #11335

Switching `bpf.datapathMode` in place **doesn't work as a config flip**: `cilium-agent` refuses to start in `veth` mode while **netkit endpoints still exist on the node** -

```
Cannot start cilium-agent with datapath-mode=veth: detected 47 existing endpoint(s) using netkit datapath mode. Please delete these pods or change the datapath mode back to netkit
```

- so 2/3 agents CrashLooped after #11335 merged. My PR body's "no hard cutover" was wrong.

## The correct way to migrate datapath mode (for a future attempt)

It's a **rolling per-node drain**, like a Talos upgrade - not an in-place change:

1. `kubectl cordon <node>`
2. `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data` (all pods leave → their netkit endpoints go away)
3. The cilium agent on that node restarts and now comes up in `veth` (no netkit endpoints left)
4. `kubectl uncordon <node>`
5. **Wait for Ceph `HEALTH_OK`** before the next node (same mon-PDB constraint we hit on the Talos upgrade)
6. Repeat for every node.

Do it in a maintenance window with the datapath change already in Git, so each drained node's pods come back as veth.

## This PR

Just restores `datapathMode: netkit` so the cluster is healthy and Flux is consistent. Re-do veth via the rolling-drain procedure above if/when pursuing Kata again (#11332).