### PR TITLE
feat: drop privileged from the home-operations runner container

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -42,10 +42,13 @@ spec:
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
             securityContext:
-              privileged: true
+              capabilities:
+                add:
+                  - NET_ADMIN
             resources:
               limits:
                 devices.kubevirt.io/kvm: 1
+                devices.kubevirt.io/tun: 1
         securityContext:
           fsGroup: 1001
           fsGroupChangePolicy: OnRootMismatch

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
@@ -28,6 +28,13 @@ spec:
                   - count: 20
                     paths:
                       - path: /dev/kvm
+              - --device
+              - |
+                name: tun
+                groups:
+                  - count: 20
+                    paths:
+                      - path: /dev/net/tun
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
## What

- **generic-device-plugin**: advertise `/dev/net/tun` as `devices.kubevirt.io/tun` (alongside `kvm`).
- **home-operations runner**: replace the runner container's `securityContext.privileged: true` with `capabilities.add: [NET_ADMIN]` + request `devices.kubevirt.io/tun: 1` (kvm request kept).

## Why

The QEMU e2e (miroir#302) only needs the runner container to create bridge/TAP interfaces + iptables NAT for the Talos VMs - which `NET_ADMIN` + `/dev/net/tun` + `/dev/kvm` covers - not *full* privilege. This drops the runner container from "all capabilities + all host devices + no seccomp" to a targeted set.

Experimental: validating whether the QEMU e2e still passes with the reduced privilege. The **dind sidecar stays privileged** (Docker needs it) - this only de-escalates the runner container.