### PR TITLE
feat: add SYS_ADMIN to the home-operations runner

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
               capabilities:
                 add:
                   - NET_ADMIN
+                  - SYS_ADMIN
             resources:
               limits:
                 devices.kubevirt.io/kvm: 1


### PR DESCRIPTION
Follow-up to #11338. `NET_ADMIN` alone can't run the QEMU e2e - the Talos provisioner does `mount --make-rshared /var/run/netns` (CNI setup), which needs `CAP_SYS_ADMIN`. Adds it, giving the minimal working set `NET_ADMIN + SYS_ADMIN`.

Still meaningfully below full `privileged: true`: only 2 added caps (not all ~40), only `/dev/kvm` + `/dev/net/tun` exposed (not all host devices), seccomp retained. (SYS_ADMIN is powerful, so this is defense-in-depth, not zero-privilege.) dind sidecar unchanged.