### PR TITLE
fix(actions-runner): scale runners to zero when idle

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: home-operations-runner
+  name: &name home-operations-runner
 spec:
   chartRef:
     kind: OCIRepository
@@ -24,7 +24,7 @@ spec:
     template:
       metadata:
         labels:
-          runner: &name home-operations-runner
+          runner: *name
       spec:
         affinity:
           podAntiAffinity:

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-operations/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
     githubConfigSecret: home-operations-runner-secret
     runnerScaleSetName: home-operations-onedr0p
     runnerGroup: home-operations
-    minRunners: 3
+    minRunners: 0
     maxRunners: 3
     containerMode:
       type: dind

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     githubConfigUrl: https://github.com/onedr0p/home-ops
     githubConfigSecret: home-ops-runner-secret
-    minRunners: 1
+    minRunners: 0
     maxRunners: 3
     containerMode:
       type: kubernetes
@@ -27,7 +27,17 @@ spec:
       name: actions-runner-controller
       namespace: actions-runner-system
     template:
+      metadata:
+        labels:
+          runner: *name
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    runner: *name
+                topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:0c6f38e8194f6c3714aa86c6dc8a72574484818ed625dd66074920b25c118508


### PR DESCRIPTION
## Changes

- Set `minRunners: 0` on both the `home-ops-runner` and `home-operations-runner` scale sets so runners only spin up when jobs are queued (was 1 and 3 respectively; `maxRunners: 3` unchanged).
- Add the same required `podAntiAffinity` on `kubernetes.io/hostname` to the `home-ops-runner` template that the `home-operations-runner` already has, so concurrent runners spread across nodes.