### PR TITLE
feat(container): update slskd to 0.26.0 and migrate config

### DIFF
--- a/kubernetes/apps/default/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/slskd/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/slskd/slskd
-              tag: 0.25.1@sha256:ab9ed50e028b524cefdb7c1dd8ebca368a076e18441ee8ac2326473eb850b4c3
+              tag: 0.26.0@sha256:ecd4026d4f8fb504e2cc55323efa2c1f5b56d20d3686b018249cc36b48ea17a6
             env:
               DOTNET_BUNDLE_EXTRACT_BASE_DIR: /tmp/.net
               TZ: America/New_York
@@ -111,9 +111,16 @@ spec:
             directories:
               downloads: /media/Downloads/soulseek/complete
               incomplete: /media/Downloads/soulseek/incomplete
-            permissions:
-              file:
-                mode: 750
+            transfers:
+              download:
+                destination:
+                  permissions:
+                    mode: 750
+                retry:
+                  partial: resume
+                  attempts: 3
+                  delay: 5000
+                  max_delay: 60000
             shares:
               directories:
                 - /media/Downloads/soulseek/shared


### PR DESCRIPTION
## Changes

Re-applies the slskd 0.26.0 bump that was reverted in #11340, along with the config migration required to make it start.

- Update `ghcr.io/slskd/slskd` from 0.25.1 to 0.26.0 (digest verified against ghcr.io, same as the original Renovate bump).
- Migrate `permissions.file.mode: 750` to the new `transfers.download.destination.permissions.mode` key. 0.26.0 refuses to start when the old key is present, which is what broke the original bump.
- Enable the new failed-download retry feature (`transfers.download.retry`): resume partial downloads, up to 3 attempts, 5s initial delay with exponential backoff capped at 60s. Note the key is `partial`, not `incomplete` as shown in the release notes; it was renamed in slskd/slskd#1743 before release.

Release notes: https://github.com/slskd/slskd/releases/tag/0.26.0