### PR TITLE
feat(miroir): enable CSIVolumeGroupSnapshot feature gate

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -13,6 +13,8 @@ spec:
     autoEvictAfter: 1h
     drbd:
       alExtents: 6007
+    groupSnapshots:
+      enabled: true
     monitoring:
       dashboards:
         enabled: true


### PR DESCRIPTION
Enables the `CSIVolumeGroupSnapshot` feature gate on the miroir chart's `csi-snapshotter` sidecar via `groupSnapshots.enabled: true`.

### Why

Validating miroir `0.11.8` (#11322), `VolumeGroupSnapshot` requests never complete: the cluster `snapshot-controller` binds a `VolumeGroupSnapshotContent` and emits `CreatingGroupSnapshot`, then waits indefinitely (`readyToUse: false`, content `status: null`, no member `VolumeSnapshots`, no `MiroirSnapshotGroup` CR) — while an identical single `VolumeSnapshot` completes in ~2s.

Root cause: the chart only adds `--feature-gates=CSIVolumeGroupSnapshot=true` to the `csi-snapshotter` sidecar when `groupSnapshots.enabled` is set (off by default). Without it the sidecar (v8.6.0, where the gate defaults to `false`) never reconciles the group content.

The cluster-side prerequisites the chart notes for this toggle are already met:
- `groupsnapshot.storage.k8s.io/v1` CRDs are installed.
- `snapshot-controller` runs with `--feature-gates=CSIVolumeGroupSnapshot=true`.

### Change

```yaml
    groupSnapshots:
      enabled: true
```

Rendered result (`helm template --set groupSnapshots.enabled=true`):

```
- name: csi-snapshotter
  args:
    - --csi-address=/csi/csi.sock
    - --timeout=120s
    - --leader-election=...
    - --feature-gates=CSIVolumeGroupSnapshot=true
```

Single `VolumeSnapshot` and PVC clone already work and are unaffected by this change.
