### PR TITLE
feat(tuppr): silence expected alerts during talos upgrades

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -11,6 +11,10 @@ spec:
   interval: 1h
   values:
     replicaCount: 2
+    silences:
+      enabled: true
+      alertmanager:
+        address: http://kube-prometheus-stack-alertmanager.o11y.svc.cluster.local:9093
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -5,9 +5,6 @@ kind: KubernetesUpgrade
 metadata:
   name: kubernetes
 spec:
-  kubernetes:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.2
   healthChecks:
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
@@ -21,3 +18,6 @@ spec:
       kind: CephCluster
       expr: |-
         status.ceph.health in ['HEALTH_OK']
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.2

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,6 +10,11 @@ spec:
     version: v1.13.6
   policy:
     rebootMode: powercycle
+  silences:
+    - matchers:
+        - name: alertname
+          value: ^(CephDaemonSlowOps|CephHealthWarning|CephMonDown|CephMonDownQuorumAtRisk|CephOSDDown|CephOSDDownHigh|CephOSDHostDown|CephSlowOps|KubeNodeEviction|KubeNodeNotReady|KubeNodeReadinessFlapping|KubeNodeUnreachable|TargetDown)$
+          matchType: "=~"
   healthChecks:
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -5,16 +5,6 @@ kind: TalosUpgrade
 metadata:
   name: talos
 spec:
-  talos:
-    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.6
-  policy:
-    rebootMode: powercycle
-  silences:
-    - matchers:
-        - name: alertname
-          value: ^(CephDaemonSlowOps|CephHealthWarning|CephMonDown|CephMonDownQuorumAtRisk|CephOSDDown|CephOSDDownHigh|CephOSDHostDown|CephSlowOps|KubeNodeEviction|KubeNodeNotReady|KubeNodeReadinessFlapping|KubeNodeUnreachable|TargetDown)$
-          matchType: "=~"
   healthChecks:
     - apiVersion: kopiur.home-operations.com/v1alpha1
       kind: Snapshot
@@ -28,3 +18,13 @@ spec:
       kind: CephCluster
       expr: |-
         status.ceph.health in ['HEALTH_OK']
+  policy:
+    rebootMode: powercycle
+  silences:
+    - matchers:
+        - name: alertname
+          value: ^(CephDaemonSlowOps|CephHealthWarning|CephMonDown|CephMonDownQuorumAtRisk|CephOSDDown|CephOSDDownHigh|CephOSDHostDown|CephSlowOps|KubeNodeEviction|KubeNodeNotReady|KubeNodeReadinessFlapping|KubeNodeUnreachable|TargetDown)$
+          matchType: "=~"
+  talos:
+    # renovate: datasource=custom.talos-factory depName=siderolabs/talos
+    version: v1.13.6


### PR DESCRIPTION
Enables tuppr's [Alertmanager silences](https://tuppr.home-operations.com/talos-upgrades/#alertmanager-silences) feature so expected node/storage alerts are silenced while a Talos upgrade runs. tuppr holds a short silence and re-extends it on every reconcile, so it lapses automatically if the controller crashes or the upgrade finishes.

- Helm values: `silences.enabled: true` pointing at `http://kube-prometheus-stack-alertmanager.o11y.svc.cluster.local:9093` (no auth headers needed, so no secret).
- `TalosUpgrade` spec: a `silences` matcher covering the alerts that fire during a node reboot: `KubeNodeNotReady/Unreachable/Eviction/ReadinessFlapping`, `CephMonDown(QuorumAtRisk)`, `CephOSDDown/DownHigh/HostDown`, `CephSlowOps`, `CephDaemonSlowOps`, `CephHealthWarning`, and `TargetDown`. Uses the default 4h `maxDuration`.

Validated: `helm template` with chart 0.4.1 renders `ALERTMANAGER_ADDRESS` from the new values, and the `TalosUpgrade` passes `kubectl apply --dry-run=server` against the live CRD (the dry-run warning about a missing Alertmanager connection is expected until the HelmRelease change rolls out). Alert names were checked against the rules loaded in Prometheus.