### PR TITLE
feat(miroir): add VolumeGroupSnapshotClass

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./miroirnodegroup.yaml
   - ./storageclass.yaml
+  - ./volumegroupsnapshotclass.yaml
   - ./volumesnapshotclass.yaml

--- a/kubernetes/apps/miroir-system/miroir/config/volumegroupsnapshotclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/volumegroupsnapshotclass.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1.json
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: miroir
+driver: miroir.home-operations.com
+deletionPolicy: Delete


### PR DESCRIPTION
## What

Add a `VolumeGroupSnapshotClass` named `miroir` for the miroir CSI driver.

## Why

`groupSnapshots.enabled: true` and the `CSIVolumeGroupSnapshot` feature gate (#11364) are enabled on the controller/snapshot-controller, and the `csi-snapshotter` sidecar is wired for group snapshots — but no `VolumeGroupSnapshotClass` existed in the cluster, so `VolumeGroupSnapshot` objects can't be provisioned.

Surfaced during the `0.11.9` post-upgrade validation in #11322: creating a temporary `VolumeGroupSnapshotClass` of this exact shape made group snapshots work end-to-end — a group snapshot over multiple PVCs reached `readyToUse`, fanned out to per-PVC member `VolumeSnapshot`s, and restored with sha256-verified data integrity.

## Details

Mirrors the existing `VolumeSnapshotClass` — same `miroir.home-operations.com` driver and `Delete` deletion policy.

Validated with `kubectl kustomize` and `kubectl apply --dry-run=server` against the live CRD.
