### PR TITLE
feat(talos): update siderolabs/talos (v1.13.7 ➔ v1.14.0-beta.0)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.7
+    version: v1.14.0-beta.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -48,7 +48,7 @@ machine:
   install:
     diskSelector:
       model: MK000480GWCEV
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.13.7
+    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0-beta.0
     wipe: false
   kernel:
     modules:


### PR DESCRIPTION
## What

Upgrade Talos from v1.13.7 to v1.14.0-beta.0 (released 2026-07-23) via tuppr, and bump the
installer image in `talos/machineconfig.yaml.j2` to match.

This unblocks #11359: the `kata-qemu` containerd handler
(siderolabs/extensions#1157, merged 2026-07-21) ships in the kata-containers sysext
built for the 1.14 track.

## Verification

- The extensions `v1.14.0-beta.0` tag contains the kata-qemu handler merge commit
  (`85e5dca`), while `v1.13.7` does not (it diverged onto release-1.13 before the merge).
  The Image Factory serves a different `kata-containers:3.32.0` digest for
  `v1.14.0-beta.0` (`sha256:a230c64f…`) than for `v1.13.7` (`sha256:5e16a488…`), and
  Talos 1.14 CI includes a kata-qemu RuntimeClass test (siderolabs/talos@5b6ed0068).
- All extensions in `talos/schematic.yaml.j2` are published for `v1.14.0-beta.0` per the
  factory's official extensions list: drbd 9.3.3, i915/xe 20260622, intel-ucode 20260512,
  kata-containers 3.32.0, mei, thunderbolt.
- Kubernetes v1.36.3 is within Talos 1.14's supported window (default 1.37.0-beta.0,
  6 versions back → 1.32–1.37).

## Release-note review against this cluster

- **etcd HTTP endpoints moved 2379 → 2383**: not applicable — machineconfig sets
  `listen-metrics-urls: http://0.0.0.0:2381`, and per the release notes customized
  metrics URLs do not move. The kube-prometheus-stack `kubeEtcd` scrape (chart default
  port 2381) keeps working.
- **`noexec` on EPHEMERAL**: new machines only; upgrades are unaffected. No Longhorn v1
  here anyway (rook-ceph + miroir/DRBD).
- **Workload isolation (sandboxd)**: opt-in via `SecurityProfileConfig`; upgraded
  clusters keep the non-isolated behavior. Not enabled in this PR.
- **NRI now enabled by default** in CRI containerd; nothing in the cluster consumes NRI,
  no impact expected.
- **Config deprecations** (v1alpha1 `.machine.sysctls`, `.machine.files`,
  `.machine.kernel`, `.cluster.*`, `machine.features.hostDNS`, etc. moving to
  multi-docs): all still supported for backwards compatibility; the machineconfig
  template is left as-is and can migrate later.
- **`talosctl apply-config --mode=reboot` removed**: not used in `talos/mod.just`.
- **NTS on by default** for the default `time.cloudflare.com` server; no custom
  TimeServerConfig present.

## Rollout

tuppr rolls the nodes one at a time with `rebootMode: powercycle`, gated by the existing
health checks (kopiur Snapshot/Restore idle, Ceph `HEALTH_OK`).

Once all three nodes are on v1.14.0-beta.0, #11359 can proceed per its runbook
(RuntimeClass → veth flip → rolling reboots).

## Caveats

This is a pre-release on the production cluster. Downgrading Talos across a minor
version is not supported once upgraded, so bail-out is roll-forward to newer 1.14
pre-releases/stable.