### PR TITLE
feat(talos): cap kubelet parallel image pulls at 3

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -206,6 +206,7 @@ labels:
 apiVersion: v1alpha1
 kind: KubeletConfig
 config:
+  maxParallelImagePulls: 3
   serializeImagePulls: false
   shutdownGracePeriod: 90s
   shutdownGracePeriodCriticalPods: 60s


### PR DESCRIPTION
Sets `maxParallelImagePulls: 3` in the `KubeletConfig` document. The kubelet currently runs with `serializeImagePulls: false` and no cap, so all pending image pulls run concurrently. This bounds it to 3 parallel pulls per node.

Field verified against kubelet v0.36.3 `KubeletConfiguration` (v1beta1): `maxParallelImagePulls` is only valid when `serializeImagePulls` is false, which is already the case.

Rendered and `talosctl validate -m metal` passes (talosctl v1.14.0-beta.0); the rendered `KubeletConfig` carries the new field. Rollout is the usual no-reboot `just talos apply-node` (kubelet restarts to pick up its config).