### PR TITLE
feat(talos): anycast control-plane endpoint via native BGP

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -80,6 +80,21 @@ parent: bond0
 mtu: 9000
 ---
 apiVersion: v1alpha1
+kind: DummyLinkConfig
+name: dummy0
+addresses:
+  - address: 192.168.66.1/32
+---
+apiVersion: v1alpha1
+kind: BGPPeerConfig
+localASN: 64515
+advertise:
+  - dummy0
+neighbors:
+  - address: 192.168.67.1
+    peerASN: 64513
+---
+apiVersion: v1alpha1
 kind: ResolverConfig
 hostDNS:
   enabled: true
@@ -230,6 +245,7 @@ apiVersion: v1alpha1
 kind: KubeAPIServerConfig
 certExtraSANs:
   - k8s.internal
+  - 192.168.66.1
 extraArgs:
   enable-aggregator-routing: "true"
   feature-gates: HPAScaleToZero=true

--- a/talos/nodes/k8s-0.yaml.j2
+++ b/talos/nodes/k8s-0.yaml.j2
@@ -10,3 +10,16 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: bond0.67
+vlanID: 67
+parent: bond0
+mtu: 9000
+addresses:
+  - address: 192.168.67.10/24
+---
+apiVersion: v1alpha1
+kind: BGPPeerConfig
+routerID: 192.168.67.10

--- a/talos/nodes/k8s-1.yaml.j2
+++ b/talos/nodes/k8s-1.yaml.j2
@@ -10,3 +10,16 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: bond0.67
+vlanID: 67
+parent: bond0
+mtu: 9000
+addresses:
+  - address: 192.168.67.11/24
+---
+apiVersion: v1alpha1
+kind: BGPPeerConfig
+routerID: 192.168.67.11

--- a/talos/nodes/k8s-2.yaml.j2
+++ b/talos/nodes/k8s-2.yaml.j2
@@ -10,3 +10,16 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
+---
+apiVersion: v1alpha1
+kind: VLANConfig
+name: bond0.67
+vlanID: 67
+parent: bond0
+mtu: 9000
+addresses:
+  - address: 192.168.67.12/24
+---
+apiVersion: v1alpha1
+kind: BGPPeerConfig
+routerID: 192.168.67.12


### PR DESCRIPTION
Adds a host-level anycast endpoint for the Kubernetes API using the native BGP speaker introduced in Talos 1.14 (`BGPPeerConfig`). Each node advertises `192.168.66.1/32` from a `dummy0` link to the UDM over a dedicated peering VLAN. Unlike the existing Cilium-advertised `kube-api` LoadBalancer (`192.168.69.120`), this endpoint survives Cilium being down, making `k8s.internal` usable for recovery when the CNI is broken.

## What this adds

- `DummyLinkConfig` `dummy0` holding the anycast address `192.168.66.1/32` (all nodes)
- `BGPPeerConfig` with `localASN: 64515`, advertising `dummy0`, peering with the UDM (`192.168.67.1`, ASN 64513); per-node `routerID` in the node patches
- `VLANConfig` `bond0.67` per node with static addresses `192.168.67.10-12/24` - a dedicated peering VLAN so the host BGP sessions have distinct source IPs from Cilium's existing sessions (FRR keys peers by source address, so the two speakers cannot share node IPs)
- `192.168.66.1` added to apiserver `certExtraSANs` for by-IP access

The anycast address is intentionally outside every connected subnet (LAN, node subnet, peering VLAN, LB pool). This is a failure-mode-clarity choice, not a hard requirement: while sessions are up the BGP /32s win longest-prefix-match over any connected /24 either way. But if the address lived inside a connected subnet, a BGP outage would fall back to the connected route and ARP - with all three nodes answering for the same IP (ARP flux), traffic would nondeterministically keep flowing and mask the failure. Outside any subnet, BGP down = cleanly unreachable. It also can't come from `192.168.69.0/24` because Cilium LBIPAM allocates Service IPs from that pool and could hand it out. The peering-VLAN addresses (`192.168.67.10-12`) are where the sessions live and where traffic is next-hopped; `192.168.66.1` is the destination advertised over them.

Verified against the 1.14 source and live nodes: the Talos speaker binds port 179 but Cilium's BGP runs active-connect only (nothing listens on 179 on the nodes today), so the two coexist. BFD is intentionally left out of this round: whether the UDM runs FRR's `bfdd` is unconfirmed, and Talos-side behavior when BFD never establishes is unverified. Follow-up once `vtysh -c "show daemons"` on the UDM confirms `bfdd`.

## Health semantics

The host advertisement is not apiserver-health-aware (it withdraws only if the node dies), unlike the Cilium LB with `externalTrafficPolicy: Local`. This is acceptable because internal clients reach the API via KubePrism (which health-checks backends) and external clients keep using `k8s.turbo.ac` on the Cilium VIP. The anycast IP is primarily a Cilium-independent path for `k8s.internal`.

## UDM configuration (apply before rolling this out)

New peering VLAN 67, `192.168.67.0/24`, UDM at `192.168.67.1`, tagged on the node trunk ports (native VLAN stays SERVERS/42 - VLANs 70/90 already ride these ports tagged).

UniFi accepts only one BGP config upload per device, so the existing config is replaced with this merged version (existing Cilium `k8s` peer-group + new `k8s-host` peer-group). Re-uploading briefly bounces the existing Cilium sessions:

```
router bgp 64513
  bgp router-id 192.168.1.1
  no bgp ebgp-requires-policy

  neighbor k8s peer-group
  neighbor k8s remote-as 64514

  neighbor 192.168.42.10 peer-group k8s
  neighbor 192.168.42.11 peer-group k8s
  neighbor 192.168.42.12 peer-group k8s

  neighbor k8s-host peer-group
  neighbor k8s-host remote-as 64515

  neighbor 192.168.67.10 peer-group k8s-host
  neighbor 192.168.67.11 peer-group k8s-host
  neighbor 192.168.67.12 peer-group k8s-host

  address-family ipv4 unicast
    maximum-paths 3
    neighbor k8s next-hop-self
    neighbor k8s soft-reconfiguration inbound
    neighbor k8s-host next-hop-self
    neighbor k8s-host soft-reconfiguration inbound
  exit-address-family
exit
```

`maximum-paths 3` also upgrades the existing Cilium-advertised VIP from single-best-path failover to true ECMP (FRR's eBGP default is 1) - worth applying even independently of this PR.

## Rollout order

1. ~~UDM: create VLAN 67~~ done - `192.168.67.1` verified reachable; no port changes needed for tagging (VLANs 70/90 already ride the node trunks with native VLAN SERVERS/42)
2. UDM: upload the merged FRR config above (replaces the existing BGP config; brief Cilium session bounce)
3. Apply this config to the nodes (no reboot; adds `bond0.67` + `dummy0` and starts the host BGP sessions)
4. Verify: `talosctl get bgppeerstatus` per node, `vtysh -c "show bgp summary"` on the UDM, `192.168.66.1/32` shows 3 ECMP paths in `show ip route`, and `curl -k https://192.168.66.1:6443/version` answers from another VLAN
5. Point `k8s.internal` DNS at `192.168.66.1` (currently resolves to the Cilium VIP)

## Validation

Rendered all three nodes with real secrets and `talosctl validate -m metal` passes (talosctl v1.14.0-beta.0). Confirmed the per-node `BGPPeerConfig` patch (routerID) merges correctly with the base document (ASN/advertise/neighbors) and each node carries its own `bond0.67` address.
