### PR TITLE
fix(talos): route anycast-sourced traffic back via peering VLAN

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -95,6 +95,12 @@ neighbors:
     peerASN: 64513
 ---
 apiVersion: v1alpha1
+kind: RoutingRuleConfig
+name: "100"
+src: 192.168.66.1/32
+table: 100
+---
+apiVersion: v1alpha1
 kind: ResolverConfig
 hostDNS:
   enabled: true

--- a/talos/nodes/k8s-0.yaml.j2
+++ b/talos/nodes/k8s-0.yaml.j2
@@ -19,6 +19,9 @@ parent: bond0
 mtu: 9000
 addresses:
   - address: 192.168.67.10/24
+routes:
+  - gateway: 192.168.67.1
+    table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPPeerConfig

--- a/talos/nodes/k8s-1.yaml.j2
+++ b/talos/nodes/k8s-1.yaml.j2
@@ -19,6 +19,9 @@ parent: bond0
 mtu: 9000
 addresses:
   - address: 192.168.67.11/24
+routes:
+  - gateway: 192.168.67.1
+    table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPPeerConfig

--- a/talos/nodes/k8s-2.yaml.j2
+++ b/talos/nodes/k8s-2.yaml.j2
@@ -19,6 +19,9 @@ parent: bond0
 mtu: 9000
 addresses:
   - address: 192.168.67.12/24
+routes:
+  - gateway: 192.168.67.1
+    table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPPeerConfig


### PR DESCRIPTION
Follow-up to #11391. The anycast endpoint accepted TCP handshakes but hung on any data transfer for clients sharing L2 with the nodes (e.g. hosts on 192.168.42.0/24): inbound traffic arrived via the UDM on VLAN 67, but replies sourced from `192.168.66.1` left via the nodes' default route directly over the shared segment. The UDM's conntrack never saw the reply direction, left the flow half-open, and dropped all subsequent client packets as invalid. Telnet/raw TCP connects still "succeeded" because the SYN-ACK reached the client directly - only payload traffic died.

Fix: policy routing so replies take the same path in reverse -

- `RoutingRuleConfig` (priority 100): traffic sourced from `192.168.66.1/32` uses routing table 100
- per-node default route in table 100 via `192.168.67.1` on `bond0.67` (`destination` omitted = default route; an explicit `0.0.0.0/0` fails validation)

All flows to the anycast IP are now symmetric through the UDM, so conntrack tracks both directions. Verified live on all three nodes after apply: 8/8 TLS requests succeed across ECMP source-port hashing, `/livez` returns 200, the serving cert carries the `192.168.66.1` SAN, and authenticated `kubectl --server=https://192.168.66.1:6443 get nodes` works. BGP sessions unaffected (they're sourced from the VLAN 67 addresses, not the anycast IP).

Already applied to k8s-0/1/2 (no reboot). Remaining rollout step from #11391: point `k8s.internal` DNS at `192.168.66.1`.