### PR TITLE
feat(network): fast BGP hold timers for quicker anycast failover

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -32,6 +32,9 @@ kind: CiliumBGPPeerConfig
 metadata:
   name: l3-bgp-peer-config
 spec:
+  timers:
+    holdTimeSeconds: 9
+    keepAliveTimeSeconds: 3
   families:
     - afi: ipv4
       safi: unicast

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -93,6 +93,7 @@ advertise:
 neighbors:
   - address: 192.168.67.1
     peerASN: 64513
+    holdTime: 9s
 ---
 apiVersion: v1alpha1
 kind: RoutingRuleConfig


### PR DESCRIPTION
Follow-up to #11391/#11392. The UDM's FRR runs only `zebra` and `bgpd` (no `bfdd`, verified via `vtysh -c "show daemons"`), so BFD is not an option for fast failure detection. This tunes BGP hold timers instead on both speakers:

- **Talos** (`BGPPeerConfig`): `holdTime: 9s` on the UDM neighbor - covers the anycast `192.168.66.1` host routes
- **Cilium** (`CiliumBGPPeerConfig`): `holdTimeSeconds: 9` / `keepAliveTimeSeconds: 3` - covers the `192.168.69.x` LB VIP advertisements

Hold time is negotiated to the minimum both peers offer, so no UDM-side FRR change is needed. Graceful shutdowns already withdraw routes instantly; this only shrinks the stale-route window on *hard* node death (power loss, panic) from the 90s default to ~9s. Keepalive overhead is one packet per ~3s per session. 9s/3s chosen over the 3s/1s floor deliberately - lower values risk session flaps from transient congestion, which would cause unnecessary route withdrawals.

Rollout notes:
- Per the CRD docs, updating `holdTimeSeconds` resets the Cilium sessions once when Flux applies this (brief `192.168.69.x` withdrawal, comparable to the earlier FRR config re-upload).
- The Talos side needs the usual no-reboot `apply-config` per node after merge; each node's host session re-establishes with the new timer (applied node-by-node, so two anycast paths remain up throughout).

Validation: rendered with real secrets and `talosctl validate -m metal` passes with `holdTime: 9s` in the rendered neighbor; the Cilium manifest passes `kubectl apply --dry-run=server` against the live CRD.