### PR TITLE
feat(default): move slskd and mosquitto to deployments with kopiur-backed config storage

### DIFF
--- a/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
   values:
     controllers:
       mosquitto:
-        type: statefulset
         containers:
           app:
             image:
@@ -39,12 +38,6 @@ spec:
                 cpu: 10m
               limits:
                 memory: 100Mi
-        statefulset:
-          volumeClaimTemplates:
-            - name: config
-              storageClass: ceph-block
-              accessMode: ReadWriteOnce
-              size: 5Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -76,6 +69,8 @@ spec:
             persistence true
             persistence_location /config
     persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
       config-file:
         type: configMap
         identifier: config

--- a/kubernetes/apps/default/mosquitto/ks.yaml
+++ b/kubernetes/apps/default/mosquitto/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: mosquitto
 spec:
+  components:
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -13,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: mosquitto
-      CONTROLLER: StatefulSet
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/default/slskd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/slskd/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
   values:
     controllers:
       slskd:
-        type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -64,12 +63,6 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 1Gi
-        statefulset:
-          volumeClaimTemplates:
-            - name: config
-              storageClass: ceph-block
-              accessMode: ReadWriteOnce
-              size: 5Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -129,6 +122,8 @@ spec:
                 - Thumbs.db$
                 - \.DS_Store$
     persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
       config-file:
         type: configMap
         identifier: config

--- a/kubernetes/apps/default/slskd/ks.yaml
+++ b/kubernetes/apps/default/slskd/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: slskd
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
     - name: multus-networks
@@ -17,7 +18,6 @@ spec:
   postBuild:
     substitute:
       APP: slskd
-      CONTROLLER: StatefulSet
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Aligns slskd and mosquitto with how the other apps in `default` handle storage and controllers:

- Drop `type: statefulset` and the `volumeClaimTemplates` blocks; both now run as Deployments.
- Config storage comes from the `kopiur/backup` component (`existingClaim: {{ .Release.Name }}`), same as radarr/sonarr/etc. Capacity is the component default of 5Gi, matching the old volume claim templates.
- Remove the now-unneeded `CONTROLLER: StatefulSet` substitutes (for slskd this makes zeroscaler target the Deployment; mosquitto had no consumer of the variable).

Both apps intentionally start with fresh PVCs (`onMissingSnapshot: Continue`, no prior kopiur snapshots exist). The old `config-slskd-0` and `config-mosquitto-0` PVCs are orphaned by the StatefulSet removal and can be deleted after rollout.