### PR TITLE
feat(actions-runner): use miroir-slow-local for runner work volumes

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -23,8 +23,8 @@ metadata:
 spec:
   dependsOn:
     - name: actions-runner-controller
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: miroir-config
+      namespace: miroir-system
     - name: generic-device-plugin
       namespace: kube-system
   interval: 1h

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
       kubernetesModeWorkVolumeClaim:
         accessModes:
           - ReadWriteOnce
-        storageClassName: ceph-block
+        storageClassName: miroir-slow-local
         resources:
           requests:
             storage: 10Gi


### PR DESCRIPTION
Switch the home-ops runner `kubernetesModeWorkVolumeClaim` from `ceph-block` to `miroir-slow-local`.

`miroir-slow-local` (1 replica, node-local) over `miroir-slow` (2 replicas, quorum freeze): the work volume is per-job scratch that lives only as long as the runner pod, so replication adds write overhead without any durability benefit. `WaitForFirstConsumer` provisions on whichever node the runner lands, and all three nodes carry the `slow` pool.

Also swap the runners Kustomization dependency from `rook-ceph-cluster` to `miroir-config` (which creates the storage classes), since nothing in the runners path uses ceph anymore.