### PR TITLE
feat(kube-system): deploy ocharted OCI registry proxy

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -52,6 +52,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_BOT_APP_CLIENT_ID: op://kubernetes/github-bot/GITHUB_BOT_APP_CLIENT_ID
           GITHUB_BOT_APP_PRIVATE_KEY: op://kubernetes/github-bot/GITHUB_BOT_APP_PRIVATE_KEY
+          OCHARTED_USERNAME: op://kubernetes/ocharted/OCHARTED_USERNAME
+          OCHARTED_PASSWORD: op://kubernetes/ocharted/OCHARTED_PASSWORD
 
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -83,6 +85,11 @@ jobs:
           RENOVATE_INTERNAL_CHECKS_FILTER: strict
           RENOVATE_PLATFORM: github
           RENOVATE_PLATFORM_COMMIT: true
+          RENOVATE_SECRETS: |-
+            {
+              "OCHARTED_USERNAME": "${{ steps.load-secrets.outputs.OCHARTED_USERNAME }}",
+              "OCHARTED_PASSWORD": "${{ steps.load-secrets.outputs.OCHARTED_PASSWORD }}"
+            }
         with:
           token: ${{ steps.app-token.outputs.token }}
           renovate-version: ${{ inputs.version || 'latest' }}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -7,6 +7,15 @@
     commitMessageExtra: "({{manager}})",
     additionalBranchPrefix: "{{manager}}-",
   },
+  hostRules: [
+    {
+      description: "Authenticate against the ocharted OCI registry",
+      matchHost: "ocharted.turbo.ac",
+      hostType: "docker",
+      username: "{{ secrets.OCHARTED_USERNAME }}",
+      password: "{{ secrets.OCHARTED_PASSWORD }}",
+    },
+  ],
   packageRules: [
     // Auto-merge rules
     {

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
-  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
+  url: oci://ocharted.turbo.ac/kubernetes-sigs.github.io/descheduler/descheduler

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./intel-gpu-resource-driver/ks.yaml
   - ./metrics-server/ks.yaml
   - ./multus/ks.yaml
+  - ./ocharted/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./reloader/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.13.1
-  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
+  url: oci://ocharted.turbo.ac/kubernetes-sigs.github.io/metrics-server/metrics-server

--- a/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ocharted
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: ocharted-secret
+    template:
+      data:
+        auth: "{{ .OCHARTED_USERNAME }}:{{ .OCHARTED_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: ocharted

--- a/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
@@ -10,6 +10,9 @@ spec:
     name: ocharted
   interval: 1h
   values:
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
     auth:
       existingSecret: ocharted-secret
       bypassNetworks:

--- a/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ocharted
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ocharted
+  interval: 1h
+  values:
+    auth:
+      existingSecret: ocharted-secret
+      bypassNetworks:
+        - 10.42.0.0/16
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          path: /healthz
+          conditions: ["[STATUS] == 200"]
+      hostnames:
+        - "{{ .Release.Name }}.turbo.ac"
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/ocharted/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ocharted
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.2
+  url: oci://ghcr.io/home-operations/charts/ocharted

--- a/kubernetes/apps/kube-system/ocharted/ks.yaml
+++ b/kubernetes/apps/kube-system/ocharted/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ocharted
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/ocharted/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ocharted.turbo.ac/kubernetes-sigs.github.io/external-dns/external-dns

--- a/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ocharted.turbo.ac/kubernetes-sigs.github.io/external-dns/external-dns


### PR DESCRIPTION
## Summary

Deploys [ocharted](https://github.com/home-operations/ocharted) 0.1.2 in `kube-system` — a stateless OCI registry proxy that serves classic HTTP Helm repositories as OCI artifacts, exposed publicly at `ocharted.turbo.ac` with basic auth.

### Deployment (`kubernetes/apps/kube-system/ocharted`)
- OCIRepository + HelmRelease via `chartRef`, following the konflate layout
- Basic auth composed from the 1Password `ocharted` item (`OCHARTED_USERNAME`/`OCHARTED_PASSWORD`) via ExternalSecret, wired through `auth.existingSecret` with `reloader.stakater.com/auto` to roll the pod on credential rotation
- `auth.bypassNetworks: [10.42.0.0/16]` (pod CIDR): in-cluster Flux pulls anonymously through the public hostname, external clients must authenticate. ocharted validates the entire connection chain (TCP peer + every XFF hop), so gateway-fronted external traffic cannot spoof its way into the bypass
- Chart-managed HTTPRoute on `envoy-external` with a gatus probe against `/healthz` (`/v2/` now returns 401 anonymously)
- ServiceMonitor enabled; 512Mi memory limit sits above the 256Mi default in-memory cache

### Renovate
- `hostRules` for `ocharted.turbo.ac` (`hostType: docker`) so Renovate can resolve chart tags proxied through it — required because GitHub-hosted runners are outside the bypass networks
- Credentials loaded from 1Password in the workflow and passed as `RENOVATE_SECRETS`; the chart itself is picked up by the existing flux manager preset

### Requires before merge
- 1Password item `ocharted` in the `kubernetes` vault with `OCHARTED_USERNAME` and `OCHARTED_PASSWORD` fields

## Validation
- `kustomize build` on the app and namespace overlays
- `helm template` against the published 0.1.2 chart with these values: auth secret, bypass env var, HTTPRoute, and ServiceMonitor all render as expected
- `renovate-config-validator` clean for the new hostRules; `actionlint`/`zizmor` pass on the workflow

### charts-mirror migration
The four OCIRepositories that consumed the static `ghcr.io/home-operations/charts-mirror` artifacts now pull through ocharted instead (versions unchanged):

| App | New URL |
|---|---|
| descheduler | `oci://ocharted.turbo.ac/kubernetes-sigs.github.io/descheduler/descheduler` |
| metrics-server | `oci://ocharted.turbo.ac/kubernetes-sigs.github.io/metrics-server/metrics-server` |
| unifi-dns | `oci://ocharted.turbo.ac/kubernetes-sigs.github.io/external-dns/external-dns` |
| cloudflare-dns | `oci://ocharted.turbo.ac/kubernetes-sigs.github.io/external-dns/external-dns` |

Upstream repos were confirmed against each chart's `metadata.yaml` in charts-mirror, and the path mapping was verified end-to-end by running ocharted 0.1.2 locally and `helm pull`ing all three charts at their pinned versions through it. Since ocharted sits only in Flux's update path, the running HelmReleases are unaffected while it comes up; the OCIRepositories simply retry until it is reachable.
