### PR TITLE
chore(renovate): disable unresolvable 1password-cli lookup

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -141,6 +141,12 @@
       matchPackageNames: ["/rook-ceph/", "/rook-ceph-cluster/"],
       allowedVersions: "<1.20.0",
     },
+    {
+      description: "1Password CLI is not resolvable on GitHub, bump manually",
+      matchManagers: ["mise"],
+      matchDepNames: ["1password-cli"],
+      enabled: false,
+    },
     // Labeling rules
     {
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
Renovate maps the mise short name `1password-cli` to the aqua backend package `1password/cli` and then queries github-tags for it, but that GitHub repo does not exist (1Password distributes the CLI from its own CDN). The lookup can never succeed and produces a persistent warning on the dependency dashboard (#7066).

Disable the dep so Renovate skips the lookup; version bumps for `1password-cli` in `.mise/config.toml` remain manual (as they effectively already were).