### PR TITLE
feat(o11y): ship Talos kernel logs to VictoriaLogs

### DIFF
--- a/kubernetes/apps/o11y/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/fluent-bit/app/helmrelease.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fluent-bit
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: fluent-bit
+  interval: 1h
+  values:
+    kind: Deployment
+    replicaCount: 1
+    # Keep the kmsg receiver off the node under investigation so its
+    # pre-crash kernel logs survive a hard hang of that node
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values: ["k8s-1"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities: { drop: ["ALL"] }
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 128Mi
+    service:
+      type: LoadBalancer
+      annotations:
+        external-dns.alpha.kubernetes.io/hostname: fluent-bit.turbo.ac
+        gatus.home-operations.com/endpoint: |-
+          group: services
+          url: tcp://fluent-bit.o11y.svc:6001
+        lbipam.cilium.io/ips: 192.168.69.125
+    extraPorts:
+      - port: 6001
+        containerPort: 6001
+        protocol: TCP
+        name: kmsg
+    serviceMonitor:
+      enabled: true
+    config:
+      inputs: |
+        [INPUT]
+            Name tcp
+            Tag talos.kmsg
+            Listen 0.0.0.0
+            Port 6001
+            Format json
+            Source_Address_Key host
+      filters: ""
+      outputs: |
+        [OUTPUT]
+            Name http
+            Match talos.*
+            Host victoria-logs.o11y.svc.cluster.local
+            Port 9428
+            URI /insert/jsonline?_msg_field=msg&_time_field=talos-time&_stream_fields=host
+            Format json_lines
+            Json_Date_Key false
+            Compress gzip
+            Retry_Limit False
+  # The chart does not template externalTrafficPolicy, Local is required to
+  # preserve node source IPs for the host stream field
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Service
+              name: fluent-bit
+            patch: |
+              - op: add
+                path: /spec/externalTrafficPolicy
+                value: Local

--- a/kubernetes/apps/o11y/fluent-bit/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/fluent-bit/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/o11y/fluent-bit/app/ocirepository.yaml
+++ b/kubernetes/apps/o11y/fluent-bit/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: fluent-bit
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.57.9
+  url: oci://ghcr.io/fluent/helm-charts/fluent-bit

--- a/kubernetes/apps/o11y/fluent-bit/ks.yaml
+++ b/kubernetes/apps/o11y/fluent-bit/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: fluent-bit
+spec:
+  dependsOn:
+    - name: victoria-logs
+  interval: 1h
+  path: ./kubernetes/apps/o11y/fluent-bit/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  wait: false

--- a/kubernetes/apps/o11y/kustomization.yaml
+++ b/kubernetes/apps/o11y/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./blackbox-exporter/ks.yaml
+  - ./fluent-bit/ks.yaml
   - ./gatus-sidecar/ks.yaml
   - ./grafana-operator/ks.yaml
   - ./kromgo/ks.yaml

--- a/kubernetes/apps/o11y/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/victoria-logs/app/helmrelease.yaml
@@ -19,6 +19,16 @@ spec:
         enabled: true
     server:
       fullnameOverride: victoria-logs
+      # Keep the log store off the node under investigation, a StatefulSet pod
+      # stuck on a hung node would halt ingestion for the whole cluster
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["k8s-1"]
       persistentVolume:
         enabled: true
         storageClassName: ceph-block

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -115,6 +115,11 @@ device: /dev/watchdog0
 timeout: 5m
 ---
 apiVersion: v1alpha1
+kind: KmsgLogConfig
+name: fluent-bit
+url: tcp://192.168.69.125:6001
+---
+apiVersion: v1alpha1
 kind: KernelModuleConfig
 name: dm_thin_pool
 ---


### PR DESCRIPTION
## Motivation

k8s-1 hard-hung twice in two days (2026-07-27 and 2026-07-28, both fatal Intel CrashLog BERT records) and both times the kernel logs leading up to the freeze were lost, because nothing ships kmsg off the node. This adds remote kernel log delivery so the next hang leaves evidence.

## Design

- **Talos**: `KmsgLogConfig` document in `talos/cluster.yaml.j2` pointing every node at `tcp://192.168.69.125:6001`. Talos streams kmsg as newline-delimited JSON (`msg`, `talos-time`, `talos-level`, facility/priority/seq) over raw TCP.
- **fluent-bit** (new app in `o11y`, official OCI chart `0.57.9`): single-replica Deployment terminating that TCP stream (`tcp` input, `Format json`) and relaying to `victoria-logs` via HTTP `/insert/jsonline?_msg_field=msg&_time_field=talos-time&_stream_fields=host`. A bridge is required: VictoriaLogs and vlagent only ingest over HTTP (or syslog, which Talos does not speak) — neither can terminate a raw TCP JSON stream.
- **Per-node stream identity**: the `tcp` input injects the peer address as `host` (`Source_Address_Key`), and the Service gets `externalTrafficPolicy: Local` via a `postRenderers` patch (the chart does not template that field) so node source IPs are preserved instead of SNAT'd.
- **Placement**: fluent-bit and the victoria-logs server are both pinned off k8s-1 (`nodeAffinity NotIn`). victoria-logs is a StatefulSet pod — stuck on a hung node, it would halt ingestion cluster-wide during exactly the window that matters.

## Rollout

1. Merge; Flux deploys fluent-bit (depends on `victoria-logs`) and moves `victoria-logs-0` off k8s-1.
2. Verify the LB endpoint answers on `192.168.69.125:6001`.
3. `just talos apply-node <node>` per node to activate `KmsgLogConfig` (no reboot needed).
4. Confirm streams in vlogs: `{host="192.168.42.10"}` etc.

## Notes

- LB IP `192.168.69.125` was unused in the Cilium pool.
- The nodeAffinity pins are intended to be temporary until the k8s-1 hang root cause is resolved.
- Validated: `kustomize build`, `helm template` against chart 0.57.9 with these values, and the `KmsgLogConfig` doc against `talosctl validate` (v1.14.0-beta.0).