### PR TITLE
ci(image-pull): extract images on the self-hosted runner

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -28,10 +28,14 @@ jobs:
           patterns: kubernetes/**/*
 
   extract:
-    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    if: >-
+      ${{
+        needs.filter.outputs.changed-files != '[]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     needs: filter
     name: Image Pull - Extract Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.repository.name }}-runner
     outputs:
       images: ${{ steps.extract.outputs.images }}
     steps:


### PR DESCRIPTION
## Problem

Since #11406 moved four chart OCIRepositories (descheduler, metrics-server, external-dns ×2) to the ocharted proxy, the `Image Pull - Extract Images` job fails on every PR touching `kubernetes/**`:

```
HEAD "https://ocharted.turbo.ac/v2/kubernetes-sigs.github.io/...": basic credential not found
```

ocharted allows anonymous pulls only from the pod CIDR (`auth.bypassNetworks: 10.42.0.0/16`) and the OCIRepositories intentionally carry no `secretRef`. flate reconciles those sources anonymously from a GitHub-hosted runner, which sits outside the bypass, so both the orig and current snapshots fail (first seen on #11412, but any PR would trip it).

## Fix

Run the `extract` job on the in-cluster ARC runner (`runs-on: ${{ github.event.repository.name }}-runner`), the same as the `pull` job — runner pods live in the pod CIDR, so flate rides the same anonymous bypass Flux does. No secrets or `secretRef` reintroduced.

The job also gets the same-repo guard the `pull` job already has, since fork PRs can't (and shouldn't) target the self-hosted runner; for forks the workflow now skips end-to-end and `Image Pull - Success` still passes.