### PR TITLE
feat(kube-system): tune coredns for ipv4-only cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
       repository: mirror.gcr.io/coredns/coredns
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
+    priorityClassName: system-cluster-critical
     serviceAccount:
       create: true
     service:
@@ -27,6 +28,10 @@ spec:
             use_tcp: true
         port: 53
         plugins:
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
           - name: errors
           - name: health
             configBlock: |-
@@ -45,6 +50,7 @@ spec:
             configBlock: |-
               prefetch 20
               serve_stale
+              servfail 0
           - name: loop
           - name: reload
           - name: loadbalance


### PR DESCRIPTION
Three changes to the CoreDNS `HelmRelease`, motivated by a review of its logs and metrics.

## `template ANY AAAA` — synthesize NODATA for AAAA

The cluster is single-stack IPv4: pod CIDRs are `10.42.{0,1,2}.0/24`, node IPs are `192.168.42.x`, and `kube-dns` is `SingleStack`/`IPv4`. Pods have no IPv6 address, so an AAAA answer is unusable even when one comes back.

Despite that, **AAAA is 1,211,420 of 2,444,351 queries per pod (49.6% of all DNS traffic)**. Every one of them walks the full ndots:5 search path and gets forwarded to the upstream resolver to produce nothing. This returns a proper NODATA (NOERROR + SOA authority) locally instead.

It also removes the largest source of noise in the logs: **75 of the 93 SERVFAILs (81%) over 24h were AAAA queries**, nearly all of them `*.internal` names from `blackbox-exporter-lan`.

Plugin chain order is fixed by `plugin.cfg`, not Corefile order. At `coredns:1.14.6` it is:

```
cache(53) → autopath(58) → template(60) → hosts(62) → kubernetes(67) → forward(73)
```

so `template` fires before both `kubernetes` and `forward` — AAAA never leaves the cluster. For `*.svc.cluster.local` the result is identical to what the `kubernetes` plugin would have returned anyway on an IPv4-only cluster.

**Caveat:** this is a `.`-wide blackhole with no `fallthrough`. If IPv6 is ever introduced, or something needs to reach an IPv6-only external host, this has to be removed first — it fails silently as NODATA, not as an error.

## `priorityClassName: system-cluster-critical`

The deployment had no priority class at all, so under node memory pressure the kubelet could evict cluster DNS ahead of ordinary workloads.

## `servfail 0`

CoreDNS caches SERVFAIL for 5s by default and replays it to retrying clients. This was measurably amplifying upstream failures: **62 SERVFAILs from the upstream resolver became 93 client-visible ones**. The failures originate at the UDM (`192.168.42.1`) and are intermittent — the same names resolve fine on retry — so caching them only widens the blast radius.

Largely moot once the AAAA change lands, since it only covers the remaining ~18 A-record SERVFAILs, but it is correct on its own.

## Verification

Rendered the chart with these values and ran the resulting Corefile against `coredns:1.14.6` in a container:

- Config parses and CoreDNS starts clean, no plugin errors.
- `AAAA cloudflare.com` (a name that definitely has AAAA records) → `NOERROR`, `ANSWER: 0`, SOA in authority. Correct NODATA.
- `A github.com` → `NOERROR`, `ANSWER: 1`, resolves normally.

Also confirmed the chart renders `configBlock` with `{{ .configBlock | indent 12 }}` and no `tpl`, so the `{{ .Zone }}` Go template survives into the Corefile rather than being consumed by Helm.