### PR TITLE
chore: cut ceph mon and prometheus-adapter log noise

### DIFF
--- a/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
@@ -10,6 +10,7 @@ spec:
     name: prometheus-adapter
   interval: 1h
   values:
+    logLevel: 1
     prometheus:
       url: http://prometheus-operated.o11y.svc.cluster.local
     rules:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -12,6 +12,9 @@ spec:
   timeout: 10m
   values:
     cephClusterSpec:
+      cephConfig:
+        mon:
+          mon_cluster_log_level: info
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
The cluster produces **2,081,714 log lines / 24h**. Ceph accounts for ~64% of that, and `rook-ceph/mon` alone for **51.5%**. These two changes remove roughly **46% of total log volume** without losing anything actionable.

## `mon_cluster_log_level: info` (was `debug`)

Ceph mon emits **1,071,798 lines / 24h**, evenly split across all three mons (~4 lines/sec each, sustained). Breakdown of what those lines are, over 24h:

| Channel / level | Lines |
|---|---:|
| `audit [DBG]` | 500,491 |
| `cluster [DBG]` | 281,482 |
| `audit [INF]` | 5,880 |
| `cluster [INF]` | 864 |
| `cluster [WRN]` | 0 |

**DBG is 73% of mon output; INF is 0.6%.** The DBG traffic is `pgmap` status every 2s (`81 pgs: 81 active+clean`, cluster is `HEALTH_OK`) plus audit entries for read-only `mgr stat` polling. Raising the floor to `info` drops ~782k lines/day and keeps all 6,744 INF entries — the audit trail for mutating commands, osdmap changes, and health transitions.

Worth noting the DBG lines are also **emitted twice**. Verified against raw ingest timestamps — identical content, identical Ceph-side timestamp, ~30µs apart:

```
2026-07-31T01:59:49.58810617Z   cluster ... pgmap v95353: 81 pgs: 81 active+clean; ...
2026-07-31T01:59:49.588134863Z  cluster ... pgmap v95353: 81 pgs: 81 active+clean; ...
```

This change makes that moot for DBG rather than fixing the duplication itself.

### Why this suppresses stderr, not just the log file

The option description only mentions "cluster log file and/or external log server", so I checked `LogMonitor::log_external` in the Ceph source. The level gate sits *above* the stderr write:

```cpp
string level = channels.get_log_level(channel);
if (int log_level = LogEntry::str_to_level(level); log_level > le.prio) {
    return;   // <-- returns before any output path
}
if (g_conf().get_val<bool>("mon_cluster_log_to_stderr")) {
    cerr << channel << " " << le << std::endl;
}
```

So entries below the threshold never reach stderr, which is where the collector picks them up. `info` is a valid value per `LogEntry::str_to_level` (`debug`/`info`/`sec`/`warn`/`error`), and the option is `Can update at runtime: true`, so no daemon restart is needed.

## `logLevel: 1` for prometheus-adapter (was `4`)

**171,788 lines / 24h**, effectively all of it per-request `httplog.go` access logging — overwhelmingly the same `probe_success?labelSelector=job=nfs_probe` LIST, also duplicated. `--v=4` is the chart default, not a deliberate choice here. klog still emits errors and warnings unconditionally at `v=1`.

## Verification

- Both charts rendered with the new values: CephCluster gets `spec.cephConfig.mon.mon_cluster_log_level: info`, prometheus-adapter gets `--v=1`.
- `kubectl apply --dry-run=server` against the live CephCluster CRD accepts the `cephConfig` map (it is `map[string]map[string]string`, and `info` is a string).

## Deliberately not included

- **`rook-ceph/mgr` (115,475 lines)** — same `pgmap` DBG spam, but the mgr logs it locally at debug level 0, which is unconditional. There is no `clog_to_stderr` equivalent for it. The only lever is `mgr_stats_period`, which trades off monitoring granularity, so it needs a separate decision.
- **`default/app` (169,713 lines)** — zigbee2mqtt (29.6k, full device JSON on every MQTT publish), zwave (28k), brrpolice (57k across 2 replicas), radarr (20.7k). These are application-level verbosity preferences, not infrastructure noise.
- **Missing `_msg` field** on `network/envoy` and `default/brrpolice` — they emit JSON the collector is not mapping to the message field, so full-text search does not work against them in VictoriaLogs. That is a collector config bug, unrelated to volume.

Storage was never the constraint here — VictoriaLogs is at 7.1 GB on a 50Gi PVC with 90d retention. This is about signal-to-noise.