### PR TITLE
fix(o11y): correct prometheus retention size and raise memory limit

### DIFF
--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -250,6 +250,7 @@ checksum = "sha256:21194bbf41c18d9ec277545c4d14cce8597d57a9d9f494c323d8121a25de3
 url = "https://nodejs.org/dist/v26.5.1/node-v26.5.1-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:34f620b8dad6e8c9188623e46b20f1a07283dcb1b32eba471efb08ca573444b3"
 url = "https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
@@ -257,6 +258,7 @@ checksum = "sha256:2b07f09c218d473a26442bff5a90151f53f7b7c0a23bad244eda2c26303a2
 url = "https://nodejs.org/dist/v26.5.1/node-v26.5.1-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:95ca909bbb80688262c5b27d98ced7878bdecff2cf1f62069fa7c9c61afc0a5b"
 url = "https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/helmrelease.yaml
@@ -58,12 +58,12 @@ spec:
         scrapeConfigSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         retention: 30d
-        retentionSize: 50GB
+        retentionSize: 40GiB
         resources:
           requests:
             cpu: 100m
           limits:
-            memory: 2000Mi
+            memory: 4Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
Two fixes from a review of Prometheus. Its logs and runtime are otherwise clean — 195 lines over 48h, all `INFO`, all routine TSDB compaction; 133/133 targets up; zero rule evaluation failures, WAL corruptions, compaction failures, sample-limit hits, or duplicate/out-of-order samples.

## `retentionSize: 50GB` → `40GiB`

**The size-based retention guard was set above the volume capacity, so it could never fire.**

Prometheus parses byte units as base-2, so `50GB` is not 50 decimal GB — it becomes `50GiB`. Confirmed against the running instance via `/api/v1/status/flags`:

```
storage.tsdb.retention.size = 50GiB
storage.tsdb.retention.time = 30d
```

| | bytes |
|---|---:|
| `retention.size` (50 GiB) | 53,687,091,200 |
| PVC capacity (a 50Gi volume) | 52,521,566,208 |

The threshold sat **~1.17 GB above the total filesystem capacity**. The volume would have hit 100% before Prometheus deleted a single block for size, and that is before accounting for the WAL, head chunks, and compaction scratch space, none of which `retentionSize` governs.

Nothing was actually wrong at the time of the change — usage was 32.99 GB (62.8%) and the 30d time-based retention is what binds in practice. But the safety net was inoperative. `40GiB` = 42.95 GB, about 82% of the volume, leaving ~9.5 GB of headroom.

Using the explicit `GiB` suffix rather than `40GB` so the base-2 parsing is not a trap for the next reader. Validated against the live CRD with `kubectl apply --dry-run=server`, including a negative control (`40Gib` is correctly rejected) to confirm the dry-run actually exercises the pattern.

## `memory: 2000Mi` → `4Gi`

The limit is 2000Mi = **1.953 GiB**. Measured against it:

| | GiB | % of limit |
|---|---:|---:|
| Working set now | 1.828 | 93.6% |
| 7d max | 1.938 | 99.2% |
| **30d max** | **1.949** | **99.8%** |

It has not been OOMKilled — 0 restarts, no `OOMKilled` terminations in 30d — so Go's GC has been absorbing the pressure, at a CPU cost. But 99.8% of a hard limit is not a margin, and the 30d max is likely clamped *by* the limit rather than reflecting true demand.

The driver is head-series churn. Baseline is ~280–310k series, but daily maxima spike repeatedly to well above it:

```
2026-07-20   873,726   <- 2.8x baseline
2026-07-27   710,826
2026-07-25   660,561
2026-07-10   573,601
2026-07-09   521,432
```

Churn concentrates in `kubelet` (1.05 series/sec added) and `kube-state-metrics` (0.6/sec) — the signature of ephemeral pod churn, consistent with the Actions runners.

Node capacity is not a constraint: 98 GB per node, and k8s-1 is at 38% memory requested. Since only `limits.memory` is set, Kubernetes copies it to `requests.memory`, so this raises the reservation from 2000Mi to 4Gi and keeps Guaranteed QoS for memory.

## Note on rollout

Changing the resource limit rolls the Prometheus StatefulSet pod. Expect a brief scrape gap and a WAL replay on startup. The `retentionSize` change alone would not have required a restart.

## Not included

`job=apiserver` accounts for **121,318 series, ~39% of the entire TSDB**. The chart's stock relabeling drops only selected `le` buckets from four histogram families and leaves the largest offenders untouched — `apiserver_request_body_size_bytes_bucket` (18,048), `apiserver_watch_list_duration_seconds_bucket` (8,748), `apiserver_watch_cache_read_wait_seconds_bucket` (6,650), `apiserver_response_sizes_bucket` (5,416), `apiserver_watch_events_sizes_bucket` (3,978). Dropping those would cut memory and disk meaningfully, but it changes what is queryable, so it deserves its own decision.

Also unaddressed: 16 permanently-firing `KubeHpaMaxedOut` warnings. Every app HPA in `default` is `minReplicas: 0, maxReplicas: 1` driven by the `probe_success{job="nfs_probe"}` external metric, so `replicas == maxReplicas` is the normal running state and the alert is structurally guaranteed to fire whenever the apps are up.