### PR TITLE
fix(talos): migrate BGPPeerConfig to BGPInstanceConfig

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -56,7 +56,8 @@ addresses:
   - address: 192.168.66.1/32
 ---
 apiVersion: v1alpha1
-kind: BGPPeerConfig
+kind: BGPInstanceConfig
+name: main
 localASN: 64515
 advertise:
   - dummy0

--- a/talos/nodes/controlplane/k8s-0.yaml.j2
+++ b/talos/nodes/controlplane/k8s-0.yaml.j2
@@ -21,5 +21,6 @@ routes:
     table: 100
 ---
 apiVersion: v1alpha1
-kind: BGPPeerConfig
+kind: BGPInstanceConfig
+name: main
 routerID: 192.168.67.10

--- a/talos/nodes/controlplane/k8s-1.yaml.j2
+++ b/talos/nodes/controlplane/k8s-1.yaml.j2
@@ -21,5 +21,6 @@ routes:
     table: 100
 ---
 apiVersion: v1alpha1
-kind: BGPPeerConfig
+kind: BGPInstanceConfig
+name: main
 routerID: 192.168.67.11

--- a/talos/nodes/controlplane/k8s-2.yaml.j2
+++ b/talos/nodes/controlplane/k8s-2.yaml.j2
@@ -21,5 +21,6 @@ routes:
     table: 100
 ---
 apiVersion: v1alpha1
-kind: BGPPeerConfig
+kind: BGPInstanceConfig
+name: main
 routerID: 192.168.67.12


### PR DESCRIPTION
Talos v1.14.0-beta.1 replaced the `BGPPeerConfig` document kind with the named `BGPInstanceConfig` kind ([siderolabs/talos@6bba777](https://github.com/siderolabs/talos/commit/6bba77724212), landed between beta.0 and beta.1) with **no back-compat alias**. The upgrade installer strictly decodes the on-disk machine config, so the old kind aborted every installer run with:

```
error loading machine configuration: error decoding document v1alpha1/BGPPeerConfig (line 81): "BGPPeerConfig" "v1alpha1": not registered
```

This migrates the shared doc in `cluster.yaml.j2` and the per-node `routerID` docs to `BGPInstanceConfig` (name: `main`). Fields are otherwise identical.

**Note:** this config is already live — it was applied to all three nodes during the beta.1 upgrade on 2026-07-31 (remove old doc on beta.0 → upgrade → add new doc on beta.1, since neither version accepts the other's kind). Merging keeps the repo in sync with the cluster; the next render/apply is a no-op.
