### PR TITLE
feat(talos): migrate kubernetesTalosAPIAccess to KubeTalosAPIAccessConfig

### DIFF
--- a/talos/controlplane.yaml.j2
+++ b/talos/controlplane.yaml.j2
@@ -5,14 +5,6 @@ machine:
   ca:
     crt: op://kubernetes/talos/MACHINE_CA_CRT
     key: op://kubernetes/talos/MACHINE_CA_KEY
-  features:
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedKubernetesNamespaces:
-        - actions-runner-system
-        - system-upgrade
-      allowedRoles:
-        - os:admin
 cluster:
   # ca merges as a unit; crt must be repeated alongside key
   ca:
@@ -125,3 +117,11 @@ config:
 extraArgs:
   bind-address: 0.0.0.0
 image: registry.k8s.io/kube-scheduler:v1.36.3
+---
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:admin
+allowedKubernetesNamespaces:
+  - actions-runner-system
+  - system-upgrade


### PR DESCRIPTION
Talos 1.14 introduces a standalone `KubeTalosAPIAccessConfig` document (controlplane-only) and deprecates `machine.features.kubernetesTalosAPIAccess`. The two conflict: a config carrying both fails validation with `.machine.features.kubernetesTalosAPIAccess is already set in v1alpha1 config`.

This moves the roles/namespaces unchanged into the new document (appended after `KubeSchedulerConfig`, keeping the alphabetical doc order) and drops the legacy `features:` block, which had nothing else in it. Notes:

- The new document has no `enabled` field — presence with non-empty `allowedRoles` is what enables access; empty roles means blocked.
- Unlike #11436 this is **not yet applied to the cluster** — the legacy field still works on v1.14.0-beta.1, it's just deprecated. A normal per-node re-render + apply picks it up atomically (legacy removed and document added in the same apply, so the conflict validation never triggers).
