### PR TITLE
feat(talos): enable periodic filesystem scrubbing

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -111,6 +111,10 @@ kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---
 apiVersion: v1alpha1
+kind: FilesystemScrubConfig
+interval: 168h0m0s
+---
+apiVersion: v1alpha1
 kind: WatchdogTimerConfig
 device: /dev/watchdog0
 timeout: 5m


### PR DESCRIPTION
Enables weekly XFS metadata scrubbing via the new Talos 1.14 `FilesystemScrubConfig` document, matching the existing `FilesystemTrimConfig` cadence.

Scrubbing is disabled by default in Talos; adding this document enables it. Each volume is scrubbed at a stable, hash-derived time within the interval so runs are spread out across volumes and nodes.

Ref: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/filesystemscrubconfig