### PR TITLE
feat(talos): tune kubelet image gc and crashloop backoff

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -196,6 +196,9 @@ labels:
 apiVersion: v1alpha1
 kind: KubeletConfig
 config:
+  crashLoopBackOff:
+    maxContainerRestartPeriod: 60s
+  imageMaximumGCAge: 168h
   maxParallelImagePulls: 3
   serializeImagePulls: false
   shutdownGracePeriod: 90s


### PR DESCRIPTION
Adds two kubelet configuration fields:

- `imageMaximumGCAge: 168h` — garbage-collect images unused for a week, independent of disk-pressure thresholds. Keeps Renovate's superseded image tags from accumulating until the 85% high-threshold purge. Note: the kubelet resets last-used tracking on restart, so the age window restarts after node reboots/upgrades.
- `crashLoopBackOff.maxContainerRestartPeriod: 60s` — caps CrashLoopBackOff at 60s instead of 300s, so pods that crashed while a dependency (NFS, database, broker) was down recover within a minute of it returning. Beta and enabled by default since Kubernetes v1.35 (KEP-5593); per-node scope.

Refs:
- https://kubernetes.io/docs/concepts/architecture/garbage-collection/#image-maximum-age-gc
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5593-configure-the-max-crashloopbackoff-delay