### PR TITLE
fix(talos): raise anycast routing rule priority above cilium's local rule

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -68,7 +68,8 @@ neighbors:
 ---
 apiVersion: v1alpha1
 kind: RoutingRuleConfig
-name: "100"
+# name is the rule priority; it must stay above Cilium's local-table rule at 100
+name: "32000"
 src: 192.168.66.1/32
 table: 100
 ---


### PR DESCRIPTION
`RoutingRuleConfig`'s `name` field is the rule priority, not a label. Talos v1.14.0-beta.1 declares it as `RulePriority string \`yaml:"name"\`` in `pkg/machinery/config/types/network/routing_rule.go`.

The rule from #11392 was set to priority `100`, which is where Cilium relocates the IPv4 `local` table rule. Two consequences:

1. Talos keys `RoutingRuleSpec`/`RoutingRuleStatus` by `family/priority`, so both rules claim resource ID `inet4/00100` and only one is visible. `talosctl get routingrule` showed just Cilium's local rule, making ours look like it had never applied.
2. In the kernel both rules exist at priority 100, and ours is evaluated first. Every packet sourced from `192.168.66.1` is diverted to table 100 and sent out via `192.168.67.1` before the local table is ever consulted.

The visible symptom is that **no node can reach the anycast address from itself**. Inbound traffic is unaffected, because the kernel accepts any local address on input and those packets are not sourced from `192.168.66.1`. But a node dialing `192.168.66.1` has its own source address selected as `192.168.66.1`, hits the rule, and leaves the host.

That breaks apid whenever member-name resolution hands a node the anycast address for a peer. On k8s-2 it made `talosctl -n k8s-2` fail roughly 80% of the time with `dial tcp 192.168.66.1:50000: connect: no route to host`, and a 3x3 endpoint/node matrix isolated it to the self-proxy cell.

Raising the priority to `32000` keeps it below `main` (32766) so the asymmetric-path fix still applies to genuinely outbound traffic, and above `local` (100) so host-local destinations resolve locally first.

## Verification

Applied to k8s-2 only, no reboot required. The rule becomes visible at its own priority, and the failure clears:

```
p9     src=            -> RoutingTable(2004)
p100   src=            -> local
p32000 src=192.168.66.1/32 -> 100
p32766 src=            -> main
p32767 src=            -> default
```

| test | k8s-2 (patched) | k8s-0 (unpatched) |
| --- | --- | --- |
| self-proxy via own endpoint, 10x | 0 failures | n/a |
| dial 192.168.66.1 from the node, 10x | works | 10 failures |

k8s-0 and k8s-1 still need this applied.