### PR TITLE
feat(cluster): peer both BGP speakers from the server subnet and drop VLAN 67

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -41,27 +41,33 @@ varies by Network release):
 k8s.internal → 192.168.66.1
 ```
 
-### Peering VLAN
+### Two speakers, one subnet
 
-The Talos host BGP sessions need source addresses distinct from Cilium's
-(FRR keys peers by source IP), so they peer over a dedicated VLAN:
+FRR keys peers by source address, and a BGP speaker's router ID must be
+unique, so the two speakers on each node are kept apart by address rather
+than by a dedicated VLAN:
 
-- VLAN 67, subnet `192.168.67.0/24`, UDM at `192.168.67.1`
-- Nodes at `192.168.67.10-12` (static, defined per node in `talos/nodes/`)
-- Tagged on the node trunk ports; the native VLAN stays SERVERS (42)
+| speaker | ASN   | source and router ID                   | announces                               |
+| ------- | ----- | -------------------------------------- | --------------------------------------- |
+| Talos   | 64515 | `192.168.42.10-12`, the node address   | the anycast API address                 |
+| Cilium  | 64514 | `192.168.42.110-112`, a `/32` on bond0 | LoadBalancer IPs from `192.168.69.0/24` |
+
+Talos has no way to pin a numbered session's source, so it takes the node
+address the kernel would select anyway. Cilium pins both its source and its
+router ID through `CiliumBGPNodeConfigOverride` (see
+`kubernetes/apps/kube-system/cilium/app/networking.yaml`).
+
+Cilium's addresses are `/32` on purpose. A `/24` would compete with the DHCP
+address for source selection on bond0 and the winner would depend on boot
+order; a `/32` is never selected as the source for `192.168.42.1`, so Talos
+deterministically uses the node address. They also sit below the DHCP pool
+(`.150-.254`) so nothing can lease them.
 
 ### BGP
 
 UniFi accepts a single FRR config upload per device (Settings → Routing →
 BGP), so both peer-groups live in one merged config; re-uploading briefly
 bounces established sessions:
-
-- `k8s` (ASN 64514) - Cilium, peering from the node IPs on the SERVERS
-  subnet (`192.168.42.10-12`), announcing LoadBalancer Service IPs from the
-  `192.168.69.0/24` pool (see
-  `kubernetes/apps/kube-system/cilium/app/networking.yaml`)
-- `k8s-host` (ASN 64515) - the Talos host speaker, peering from VLAN 67,
-  announcing the anycast API address
 
 ```text
 router bgp 64513
@@ -71,16 +77,16 @@ router bgp 64513
   neighbor k8s peer-group
   neighbor k8s remote-as 64514
 
-  neighbor 192.168.42.10 peer-group k8s
-  neighbor 192.168.42.11 peer-group k8s
-  neighbor 192.168.42.12 peer-group k8s
+  neighbor 192.168.42.110 peer-group k8s
+  neighbor 192.168.42.111 peer-group k8s
+  neighbor 192.168.42.112 peer-group k8s
 
   neighbor k8s-host peer-group
   neighbor k8s-host remote-as 64515
 
-  neighbor 192.168.67.10 peer-group k8s-host
-  neighbor 192.168.67.11 peer-group k8s-host
-  neighbor 192.168.67.12 peer-group k8s-host
+  neighbor 192.168.42.10 peer-group k8s-host
+  neighbor 192.168.42.11 peer-group k8s-host
+  neighbor 192.168.42.12 peer-group k8s-host
 
   address-family ipv4 unicast
     maximum-paths 3

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -60,3 +60,41 @@ spec:
           peerAddress: 192.168.1.1
           peerConfigRef:
             name: l3-bgp-peer-config
+---
+# FRR keys peers by source address, so Cilium peers from a dedicated /32 to
+# leave the node address free for the Talos speaker
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgpnodeconfigoverride_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: k8s-0
+spec:
+  bgpInstances:
+    - name: cilium
+      peers:
+        - name: unifi
+          localAddress: 192.168.42.110
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgpnodeconfigoverride_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: k8s-1
+spec:
+  bgpInstances:
+    - name: cilium
+      peers:
+        - name: unifi
+          localAddress: 192.168.42.111
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumbgpnodeconfigoverride_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfigOverride
+metadata:
+  name: k8s-2
+spec:
+  bgpInstances:
+    - name: cilium
+      peers:
+        - name: unifi
+          localAddress: 192.168.42.112

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -71,6 +71,7 @@ metadata:
 spec:
   bgpInstances:
     - name: cilium
+      routerID: 192.168.42.110
       peers:
         - name: unifi
           localAddress: 192.168.42.110
@@ -83,6 +84,7 @@ metadata:
 spec:
   bgpInstances:
     - name: cilium
+      routerID: 192.168.42.111
       peers:
         - name: unifi
           localAddress: 192.168.42.111
@@ -95,6 +97,7 @@ metadata:
 spec:
   bgpInstances:
     - name: cilium
+      routerID: 192.168.42.112
       peers:
         - name: unifi
           localAddress: 192.168.42.112

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -62,7 +62,7 @@ localASN: 64515
 advertise:
   - dummy0
 neighbors:
-  - address: 192.168.67.1
+  - address: 192.168.42.1
     peerASN: 64513
     holdTime: 9s
 ---

--- a/talos/nodes/controlplane/k8s-0.yaml.j2
+++ b/talos/nodes/controlplane/k8s-0.yaml.j2
@@ -9,18 +9,16 @@ labels:
   topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
+kind: BondConfig
+name: bond0
+# /32 so the kernel never prefers it as the source for the Talos BGP session
 addresses:
-  - address: 192.168.67.10/24
+  - address: 192.168.42.110/32
 routes:
-  - gateway: 192.168.67.1
+  - gateway: 192.168.42.1
     table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPInstanceConfig
 name: main
-routerID: 192.168.67.10
+routerID: 192.168.42.10

--- a/talos/nodes/controlplane/k8s-1.yaml.j2
+++ b/talos/nodes/controlplane/k8s-1.yaml.j2
@@ -9,18 +9,16 @@ labels:
   topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
+kind: BondConfig
+name: bond0
+# /32 so the kernel never prefers it as the source for the Talos BGP session
 addresses:
-  - address: 192.168.67.11/24
+  - address: 192.168.42.111/32
 routes:
-  - gateway: 192.168.67.1
+  - gateway: 192.168.42.1
     table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPInstanceConfig
 name: main
-routerID: 192.168.67.11
+routerID: 192.168.42.11

--- a/talos/nodes/controlplane/k8s-2.yaml.j2
+++ b/talos/nodes/controlplane/k8s-2.yaml.j2
@@ -9,18 +9,16 @@ labels:
   topology.kubernetes.io/zone: m
 ---
 apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
+kind: BondConfig
+name: bond0
+# /32 so the kernel never prefers it as the source for the Talos BGP session
 addresses:
-  - address: 192.168.67.12/24
+  - address: 192.168.42.112/32
 routes:
-  - gateway: 192.168.67.1
+  - gateway: 192.168.42.1
     table: 100
 ---
 apiVersion: v1alpha1
 kind: BGPInstanceConfig
 name: main
-routerID: 192.168.67.12
+routerID: 192.168.42.12


### PR DESCRIPTION
VLAN 67 exists only because FRR keys BGP peers by source address, and both speakers were otherwise landing on the node's primary `192.168.42.x`. Talos has no way to pin a numbered session's source (`routeSource` sets `RTA_PREFSRC` on routes installed *from* BGP, and `link` only applies to unnumbered IPv6 link-local sessions), so the original fix was to move Talos onto its own subnet.

Cilium *can* pin its source, via `CiliumBGPNodeConfigOverride.spec.bgpInstances[].peers[].localAddress` ("LocalAddress is the IP address to use for connecting to this peer"). Pinning the speaker that supports it removes the need for a separate L2 segment entirely.

## Changes

- Cilium peers from a dedicated `/32` per node: `192.168.42.110/112`. These sit below the DHCP pool (`.150-.254`), so nothing will lease them.
- Talos keeps peering from the node address `192.168.42.10/12`, which the kernel selects anyway, and its neighbor moves from `192.168.67.1` to `192.168.42.1`.
- `VLANConfig bond0.67` is removed from all three node patches, along with its addresses and the VLAN itself.
- The table-100 route moves from `via 192.168.67.1 dev bond0.67` to `via 192.168.42.1 dev bond0`.
- `routerID` moves from `192.168.67.1x` to `192.168.42.1x` for Talos, and Cilium's is pinned explicitly to its own `/32`.

### Router IDs must be set on both speakers

Cilium defaults its BGP identifier to the node's InternalIP, which is the same `192.168.42.1x` that Talos now uses as its `routerID`. Two speakers on one host presenting the same BGP Identifier to the same peer violates RFC 4271 and FRR will reject or flap a session. VLAN 67 previously made this collision impossible by accident. Both are now set explicitly, each matching its own peering source, so the invariant does not depend on either implementation's default:

| node | Talos routerID / source | Cilium routerID / source |
| --- | --- | --- |
| k8s-0 | `.10` / `.10` | `.110` / `.110` |
| k8s-1 | `.11` / `.11` | `.111` / `.111` |
| k8s-2 | `.12` / `.12` | `.112` / `.112` |

The anycast address, `dummy0`, the BGP instance, and the routing rule from #11451 are all unchanged. **The API endpoint does not move**, so cert SANs, `k8s.internal`, and every kubeconfig stay exactly as they are.

### Why the Cilium addresses are `/32`

A `/24` secondary would compete with the DHCP primary for source selection on `bond0`, and which one wins is a boot-order race. Linux prefers a source address whose prefix contains the destination, so a `/32` is never selected for traffic to `192.168.42.1` and Talos deterministically uses the node address. This is the same class of race that produced the node-address bug found while debugging #11451, so it is worth avoiding by construction rather than by luck.

## Migration

`192.168.42.10-12` changes peer-group and ASN, from `k8s` (64514, Cilium) to
`k8s-host` (64515, Talos). That cannot be done atomically, so the UDM is uploaded
three times, each carrying both the old and new state for the step in flight.

UniFi replaces the whole FRR config on every upload, so each block below is the
**complete** config, not a fragment. Every upload briefly bounces established
sessions.

**1. UDM upload A** — add the future Cilium sources alongside the current ones:

```text
router bgp 64513
  bgp router-id 192.168.1.1
  no bgp ebgp-requires-policy

  neighbor k8s peer-group
  neighbor k8s remote-as 64514

  neighbor 192.168.42.10 peer-group k8s
  neighbor 192.168.42.11 peer-group k8s
  neighbor 192.168.42.12 peer-group k8s
  neighbor 192.168.42.110 peer-group k8s
  neighbor 192.168.42.111 peer-group k8s
  neighbor 192.168.42.112 peer-group k8s

  neighbor k8s-host peer-group
  neighbor k8s-host remote-as 64515

  neighbor 192.168.67.10 peer-group k8s-host
  neighbor 192.168.67.11 peer-group k8s-host
  neighbor 192.168.67.12 peer-group k8s-host

  address-family ipv4 unicast
    maximum-paths 3
    neighbor k8s next-hop-self
    neighbor k8s soft-reconfiguration inbound
    neighbor k8s-host next-hop-self
    neighbor k8s-host soft-reconfiguration inbound
  exit-address-family
exit
```

**2. Merge this PR** and let Flux apply the `CiliumBGPNodeConfigOverride` resources.
Cilium moves onto `.110-.112` and `192.168.42.10-12` goes idle:

```sh
kubectl -n kube-system exec ds/cilium -c cilium-agent -- cilium-dbg bgp peers
kubectl get ciliumbgpnodeconfigs -o yaml | rg -A2 "routerID|peerAddress"
```

**3. UDM upload B** — retire the old Cilium neighbors and pre-add the future Talos ones:

```text
router bgp 64513
  bgp router-id 192.168.1.1
  no bgp ebgp-requires-policy

  neighbor k8s peer-group
  neighbor k8s remote-as 64514

  neighbor 192.168.42.110 peer-group k8s
  neighbor 192.168.42.111 peer-group k8s
  neighbor 192.168.42.112 peer-group k8s

  neighbor k8s-host peer-group
  neighbor k8s-host remote-as 64515

  neighbor 192.168.67.10 peer-group k8s-host
  neighbor 192.168.67.11 peer-group k8s-host
  neighbor 192.168.67.12 peer-group k8s-host
  neighbor 192.168.42.10 peer-group k8s-host
  neighbor 192.168.42.11 peer-group k8s-host
  neighbor 192.168.42.12 peer-group k8s-host

  address-family ipv4 unicast
    maximum-paths 3
    neighbor k8s next-hop-self
    neighbor k8s soft-reconfiguration inbound
    neighbor k8s-host next-hop-self
    neighbor k8s-host soft-reconfiguration inbound
  exit-address-family
exit
```

**4. Apply the Talos config one node at a time**, verifying between each so the
anycast keeps two live paths throughout:

```sh
just talos apply-node k8s-0
talosctl -n k8s-0 get bgppeerstatus     # ESTABLISHED to 192.168.42.1
talosctl -n k8s-0 get addresses | rg 42.110
```

No reboot is required; this is a link and route change.

**5. UDM upload C** — drop the VLAN 67 neighbors. This is the steady-state config and
matches `bootstrap/README.md` exactly:

```text
router bgp 64513
  bgp router-id 192.168.1.1
  no bgp ebgp-requires-policy

  neighbor k8s peer-group
  neighbor k8s remote-as 64514

  neighbor 192.168.42.110 peer-group k8s
  neighbor 192.168.42.111 peer-group k8s
  neighbor 192.168.42.112 peer-group k8s

  neighbor k8s-host peer-group
  neighbor k8s-host remote-as 64515

  neighbor 192.168.42.10 peer-group k8s-host
  neighbor 192.168.42.11 peer-group k8s-host
  neighbor 192.168.42.12 peer-group k8s-host

  address-family ipv4 unicast
    maximum-paths 3
    neighbor k8s next-hop-self
    neighbor k8s soft-reconfiguration inbound
    neighbor k8s-host next-hop-self
    neighbor k8s-host soft-reconfiguration inbound
  exit-address-family
exit
```

Then delete the VLAN 67 network on the UDM and remove its tagging from the node
trunk ports.

### Verify

```sh
# three ECMP paths for the API, sourced from the server subnet
vtysh -c "show ip route 192.168.66.1"
# both sessions per node, distinct sources
vtysh -c "show bgp summary"
# API unaffected throughout
curl -k https://k8s.internal:6443/livez
```

### Rollback

Revert the PR and re-upload FRR upload A. Nodes return to VLAN 67 on the next `apply-node`, which requires VLAN 67 still existing on the UDM, so leave step 5 until you are satisfied.

## Validated

- `talosctl validate -m metal` passes on all three rendered configs.
- The per-node `BondConfig` patch merges as intended: `links: [net0]`, `bondMode`, and `mtu` are preserved from the base document, with only the `/32` and the table-100 route added. Bond membership is not clobbered.
- Remaining VLANs per node are `bond0.70` and `bond0.90`; `bond0.67` is gone.
- Per node, Cilium source and routerID resolve to `.110/.10`, `.111/.11`, `.112/.12`.

Not yet exercised against live hardware: the sessions themselves only come up once the UDM carries the new neighbors, so step 1 gates everything else.
