### PR TITLE
fix(talos): disable host ipv6 on the iot vlan interface

### DIFF
--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -162,8 +162,7 @@ params:
   net.ipv4.tcp_slow_start_after_idle: "0"
   net.ipv4.tcp_window_scaling: "1"
   net.ipv4.tcp_wmem: 4096 65536 33554432
-  # keep the host off IPv6 on the IoT segment; slash form because the interface name contains a dot
-  net/ipv6/conf/bond0.70/disable_ipv6: "1"
+  net/ipv6/conf/bond0.70/disable_ipv6: "1" # keep the host off IPv6 on the IoT segmen
   sunrpc.tcp_max_slot_table_entries: "128"
   sunrpc.tcp_slot_table_entries: "128"
   user.max_user_namespaces: "11255"

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -162,6 +162,8 @@ params:
   net.ipv4.tcp_slow_start_after_idle: "0"
   net.ipv4.tcp_window_scaling: "1"
   net.ipv4.tcp_wmem: 4096 65536 33554432
+  # keep the host off IPv6 on the IoT segment; slash form because the interface name contains a dot
+  net/ipv6/conf/bond0.70/disable_ipv6: "1"
   sunrpc.tcp_max_slot_table_entries: "128"
   sunrpc.tcp_slot_table_entries: "128"
   user.max_user_namespaces: "11255"


### PR DESCRIPTION
`bond0.70` exists on the nodes only as the macvlan master for the Multus `iot` NetworkAttachmentDefinition; the hosts have no addressing on it and no business talking on that segment. But Talos sets `net.ipv6.conf.default.accept_ra=2` as a kernel param default (`kernel_param_defaults.go`, accept RAs while forwarding), so the hosts SLAAC a ULA from the Router Advertisement that a Thread border router (a Google device at `192.168.70.209`) emits on the IoT VLAN every 30 minutes.

That address is more than cosmetic:

- It lands in every node's Talos discovery member list and KubePrism's endpoint set, so apid and node-to-node apiserver traffic ride an address leased from a smart display on a 30-minute lifetime.
- Every wildcard IPv6 listener on the hosts (kube-apiserver 6443, kubelet 10250, apid 50000, trustd 50001, controller-manager/scheduler 10257/10259, etcd metrics 2381, all NodePorts) becomes **on-link** reachable from the IoT segment, bypassing inter-VLAN firewalling entirely. The addresses are derivable by anything on the VLAN: the prefix is multicast in the RA and the interface ID is EUI-64 from the node MACs visible in L2 traffic.

## Change

One sysctl, applied per interface rather than by overriding the Talos default (which would race link creation order):

```yaml
net/ipv6/conf/bond0.70/disable_ipv6: "1"
```

The slash-form key is required because the interface name contains a dot: Talos's `Param.Path()` treats a key as slash-separated (preserving dots) when the first separator is a slash, matching sysctl(8) convention. There is no native per-link RA knob in the network config documents; the only `accept_ra` writer in the tree is the unnumbered-BGP controller.

`disable_ipv6` is preferred over `accept_ra=0` because writing it flushes existing addresses immediately instead of waiting out the RA lifetime, and because the host should have no IPv6 presence on this segment at all, link-local included.

## Rolled out and verified per node

| check | k8s-0 | k8s-1 | k8s-2 |
| --- | --- | --- | --- |
| sysctl value | 1 | 1 | 1 |
| v6 addresses on bond0.70 | none | none | none |
| KernelParamStatus | applied, supported | applied, supported | applied, supported |
| node | Ready | Ready | Ready |

Discovery member lists are back to `192.168.42.x, 192.168.66.1, 192.168.67.x` on all three, config drift is `No changes` everywhere, and the anycast API answers throughout.

The Home Assistant pod is unaffected: its `net1` is a macvlan child in its own netns with its own sysctls, and it retains its SLAAC address (`fd51:...:feaf:fb53`). Thread/Matter on the IoT VLAN is untouched since the RA itself is not filtered; the hosts just stop consuming it.

Not verified: boot-time application on an interface that does not exist yet relies on the kernel param controller's retry-on-error behavior (confirmed in source, not exercised). `KernelParamStatus` would surface a failure after the next reboot if it misbehaves.