### PR TITLE
fix(talos): resolve node names upstream instead of via discovery members

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -41,6 +41,11 @@ varies by Network release):
 k8s.internal → 192.168.66.1
 ```
 
+Node names (`k8s-0/1/2`) resolve through the UDM's DHCP lease registration
+for both the workstation and the nodes themselves; host DNS member
+resolution is disabled so the anycast address never enters apid's dial
+pool. If a node name will not resolve, use its `192.168.42.x` address.
+
 ### Peering VLAN
 
 The Talos host BGP sessions need source addresses distinct from Cilium's

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -78,7 +78,8 @@ kind: ResolverConfig
 hostDNS:
   enabled: true
   forwardKubeDNSToHost: true # Requires Cilium socketLB features
-  resolveMemberNames: true
+  # member synthesis would put the anycast address in apid's dial pool; node names resolve via the UDM instead
+  resolveMemberNames: false
 ---
 apiVersion: v1alpha1
 kind: DiscoveryServiceConfig


### PR DESCRIPTION
With `hostDNS.resolveMemberNames: true`, apid resolves node names through discovery member records, and every member advertises the anycast API address alongside its unicast addresses. Captured on the loopback of an endpoint node while proxying `talosctl -n k8s-2`:

```
A? k8s-2.  ->  A 192.168.42.12, A 192.168.66.1, A 192.168.67.12
```

The anycast in that answer set is a wrong-node hazard: a dial to `192.168.66.1:50000` self-delivers on the proxying node (the local table wins for a locally held address), so apid can serve a request labeled for one node from another. This is the same mechanism behind the `talosctl -n k8s-2` failures fixed in #11451, and it does not require a node to have elected the anycast as its default address; the record is in the dial pool on every proxy call.

## Change

Set `resolveMemberNames: false`. Node names then forward upstream to the UDM, whose DHCP lease registration answers with exactly the node's unicast address:

| resolver | answer for `k8s-2` |
| --- | --- |
| member synthesis (before) | `192.168.42.12`, `192.168.66.1`, `192.168.67.12` |
| upstream via UDM (after) | `192.168.42.12` |

The anycast leaves apid's dial pool entirely. A future default-address latch (the boot-time election race between `dummy0` and the other links, which remains unfixed upstream) degrades to a cosmetic `/etc/hosts` entry on the affected node.

## What this depends on

Node-name resolution now relies on the UDM's lease registration for the nodes as well as the workstation (which already used it). The bootstrap README notes this; the fallback is dialing by `192.168.42.x`. Bootstrap is unaffected: the maintenance-mode `apply-config --insecure` stage resolves client-side, and the `k8s`/`kubeconfig` stages retry in loops after the leases re-register with hostnames.

## Rolled out and verified per node

Each node was applied individually and its hostDNS interrogated directly (hostNetwork pod against `127.0.0.53`) before moving on: all three answer peer names with only the `.42.x` unicast address. Full 3x3 endpoint/node proxy matrix passes, 20/20 unpinned `talosctl -n k8s-2` calls succeed, and config drift is `No changes` everywhere.

Note for operators: apid caches backend connections and re-resolves only on dial, so the changed pool takes effect per connection as channels naturally re-establish. During the config apply itself there is a brief window where member records are torn down one at a time and a resolution can return a partial set; established connections mask it.