### PR TITLE
revert(talos): replace native BGP anycast with the cilium kube-api LoadBalancer

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -22,15 +22,18 @@ directory is not used again until the next rebuild.
 - A valid `talosconfig` at the repo root (mise points `TALOSCONFIG` there).
   The justfile derives the controller endpoint and node list from
   `talosctl config info`, so nothing is hardcoded here.
-- The UDM configuration below, so that `k8s.internal` resolves and routes to
-  the anycast API address before any node exists.
+- The UDM configuration below. `k8s.internal` points at the Cilium
+  LoadBalancer VIP, which exists only once Cilium is installed, so bootstrap
+  talks to the controller's node IP directly until the `apps` stage brings
+  Cilium up.
 
 ## UDM configuration
 
-Talos itself advertises the API address `192.168.66.1/32` over BGP (see
-`talos/cluster.yaml.j2`), so the Kubernetes API is reachable as soon as a
-control plane node is up; no CNI or LoadBalancer required. The router side
-of that arrangement lives on the UDM and must be in place before bootstrap:
+The Kubernetes API is fronted by a Cilium LoadBalancer Service (`kube-api`,
+`192.168.69.120`, `externalTrafficPolicy: Local` so only nodes with a
+healthy apiserver attract traffic). Cilium announces it to the UDM over BGP
+along with every other LoadBalancer IP. See
+`kubernetes/apps/kube-system/cilium/app/networking.yaml`.
 
 ### DNS record
 
@@ -38,30 +41,16 @@ A static A record in UniFi (under the policy settings; the UI location
 varies by Network release):
 
 ```text
-k8s.internal → 192.168.66.1
+k8s.internal → 192.168.69.120
 ```
-
-### Peering VLAN
-
-The Talos host BGP sessions need source addresses distinct from Cilium's
-(FRR keys peers by source IP), so they peer over a dedicated VLAN:
-
-- VLAN 67, subnet `192.168.67.0/24`, UDM at `192.168.67.1`
-- Nodes at `192.168.67.10-12` (static, defined per node in `talos/nodes/`)
-- Tagged on the node trunk ports; the native VLAN stays SERVERS (42)
 
 ### BGP
 
-UniFi accepts a single FRR config upload per device (Settings → Routing →
-BGP), so both peer-groups live in one merged config; re-uploading briefly
-bounces established sessions:
-
-- `k8s` (ASN 64514) - Cilium, peering from the node IPs on the SERVERS
-  subnet (`192.168.42.10-12`), announcing LoadBalancer Service IPs from the
-  `192.168.69.0/24` pool (see
-  `kubernetes/apps/kube-system/cilium/app/networking.yaml`)
-- `k8s-host` (ASN 64515) - the Talos host speaker, peering from VLAN 67,
-  announcing the anycast API address
+Cilium (ASN 64514) peers from the node IPs on the SERVERS subnet
+(`192.168.42.10-12`) and announces LoadBalancer Service IPs from the
+`192.168.69.0/24` pool. UniFi accepts a single FRR config upload per device
+(Settings → Routing → BGP); re-uploading briefly bounces established
+sessions:
 
 ```text
 router bgp 64513
@@ -75,29 +64,20 @@ router bgp 64513
   neighbor 192.168.42.11 peer-group k8s
   neighbor 192.168.42.12 peer-group k8s
 
-  neighbor k8s-host peer-group
-  neighbor k8s-host remote-as 64515
-
-  neighbor 192.168.67.10 peer-group k8s-host
-  neighbor 192.168.67.11 peer-group k8s-host
-  neighbor 192.168.67.12 peer-group k8s-host
-
   address-family ipv4 unicast
     maximum-paths 3
     neighbor k8s next-hop-self
     neighbor k8s soft-reconfiguration inbound
-    neighbor k8s-host next-hop-self
-    neighbor k8s-host soft-reconfiguration inbound
   exit-address-family
 exit
 ```
 
-`maximum-paths 3` gives true ECMP across the three control plane nodes
-(FRR's eBGP default is a single best path).
+`maximum-paths 3` gives true ECMP across the control plane nodes for the
+`kube-api` VIP (FRR's eBGP default is a single best path).
 
-To verify: `talosctl get bgppeerstatus` per node, `vtysh -c "show bgp
-summary"` on the UDM, and `192.168.66.1/32` showing three ECMP paths in
-`vtysh -c "show ip route"`.
+To verify: `vtysh -c "show bgp summary"` on the UDM, `192.168.69.120/32`
+showing an ECMP path per healthy apiserver in `vtysh -c "show ip route"`,
+and `curl -k https://k8s.internal:6443/livez`.
 
 ## Stages
 
@@ -108,13 +88,14 @@ summary"` on the UDM, and `192.168.66.1/32` showing three ECMP paths in
    Nodes that are already configured are skipped, so the stage is idempotent.
 2. **k8s** - Runs `talosctl bootstrap` against the controller, retrying until
    etcd reports the cluster already exists.
-3. **kubeconfig** - Fetches the kubeconfig with `talosctl kubeconfig`. The
-   generated server address is `https://k8s.internal:6443`, which routes via
-   the Talos anycast address and works for the remainder of the bootstrap.
+3. **kubeconfig** - Fetches the kubeconfig with `talosctl kubeconfig`, then
+   rewrites the server address to the controller's node IP: the generated
+   `https://k8s.internal:6443` points at the Cilium VIP, which does not
+   exist yet. The final stage re-fetches the kubeconfig so the endpoint
+   returns to `k8s.internal` once Cilium is serving it.
 4. **base** - Waits for every control plane apiserver to answer `/readyz`
-   (each node advertises the anycast address whether or not its apiserver is
-   up yet) and for nodes to register (they stay `Ready=False` until the CNI
-   is installed), then applies:
+   and for nodes to register (they stay `Ready=False` until the CNI is
+   installed), then applies:
     - `kustomize/` - bootstrap Secrets rendered through `op inject`, plus
       their namespaces: 1Password Connect credentials and token plus the
       Cloudflare tunnel ID from the personal account (`personal/`), and the
@@ -169,8 +150,9 @@ later reconcile, and Renovate updates only one place.
 
 ## Notes
 
-- The Kubernetes API endpoint does not depend on anything installed here:
-  `k8s.internal` rides the Talos-advertised anycast address, so the API stays
-  reachable even with the CNI down.
+- `k8s.internal` rides the Cilium `kube-api` LoadBalancer, so the named API
+  endpoint depends on Cilium being healthy. If the CNI is ever down, reach
+  the API directly at `https://192.168.42.10-12:6443` and the Talos API at
+  the same node addresses; neither depends on the CNI.
 - Every stage is safe to re-run. If bootstrap fails partway, fix the issue and
   run `just bootstrap cluster` again.

--- a/bootstrap/helmfile/apps.yaml
+++ b/bootstrap/helmfile/apps.yaml
@@ -22,6 +22,31 @@ defaultInherit: default
 releases:
   - name: cilium
     namespace: kube-system
+    hooks:
+      - # Wait for CRDs to be available
+        command: kubectl
+        args:
+          - wait
+          - --for=create
+          - crd/ciliumbgpadvertisements.cilium.io
+          - crd/ciliumbgpclusterconfigs.cilium.io
+          - crd/ciliumbgppeerconfigs.cilium.io
+          - crd/ciliumloadbalancerippools.cilium.io
+          - --timeout=2m
+        events:
+          - postsync
+        showlogs: true
+      - # Apply Resources
+        command: kubectl
+        args:
+          - apply
+          - --namespace={{ .Release.Namespace }}
+          - --server-side
+          - --force-conflicts
+          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/app/networking.yaml
+        events:
+          - postsync
+        showlogs: true
 
   - name: coredns
     namespace: kube-system

--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -10,7 +10,7 @@ nodes := `talosctl config info -o yaml | yq -r -e '.nodes | join (" ")'`
 
 [confirm('Bootstrap cluster? [y|N]')]
 [doc('Bootstrap a Talos & Kubernetes cluster end-to-end')]
-cluster: nodes k8s kubeconfig base apps
+cluster: nodes k8s (kubeconfig "node") base apps kubeconfig
 
 [private]
 nodes:
@@ -34,10 +34,15 @@ k8s:
     done
 
 [private]
-kubeconfig:
+kubeconfig lb="cilium":
     just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! talosctl kubeconfig -n "{{ controller }}" -f --force-context-name main {{ justfile_dir() }}; then
         just log fatal "Failed to fetch kubeconfig" "stage" "{{ recipe_name() }}"
+    fi
+    if [[ "{{ lb }}" != "cilium" ]]; then
+        if ! kubectl config set-cluster main --server "https://{{ controller }}:6443"; then
+            just log fatal "Failed to set kubectl cluster server address" "stage" "{{ recipe_name() }}"
+        fi
     fi
 
 [private]
@@ -60,7 +65,7 @@ apps:
         just log fatal "Failed to sync helmfile" "stage" "{{ recipe_name() }}"
     fi
 
-# Wait until every apiserver answers /readyz. Nodes advertise the anycast address whether or not their apiserver is up.
+# Wait until every apiserver answers /readyz. Helm and kubectl calls after this stage are not retried.
 [private]
 api-ready:
     just log info "Running stage..." "stage" "{{ recipe_name() }}"

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -60,3 +60,19 @@ spec:
           peerAddress: 192.168.1.1
           peerConfigRef:
             name: l3-bgp-peer-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-api
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: k8s.turbo.ac
+    lbipam.cilium.io/ips: 192.168.69.120
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    k8s-app: kube-apiserver
+    tier: control-plane
+  ports:
+    - port: 6443

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -50,30 +50,6 @@ parent: bond0
 mtu: 9000
 ---
 apiVersion: v1alpha1
-kind: DummyLinkConfig
-name: dummy0
-addresses:
-  - address: 192.168.66.1/32
----
-apiVersion: v1alpha1
-kind: BGPInstanceConfig
-name: main
-localASN: 64515
-advertise:
-  - dummy0
-neighbors:
-  - address: 192.168.67.1
-    peerASN: 64513
-    holdTime: 9s
----
-apiVersion: v1alpha1
-kind: RoutingRuleConfig
-# name is the rule priority; it must stay above Cilium's local-table rule at 100
-name: "32000"
-src: 192.168.66.1/32
-table: 100
----
-apiVersion: v1alpha1
 kind: ResolverConfig
 hostDNS:
   enabled: true

--- a/talos/controlplane.yaml.j2
+++ b/talos/controlplane.yaml.j2
@@ -33,7 +33,6 @@ apiVersion: v1alpha1
 kind: KubeAPIServerConfig
 certExtraSANs:
   - k8s.internal
-  - 192.168.66.1
 extraArgs:
   enable-aggregator-routing: "true"
   feature-gates: HPAScaleToZero=true

--- a/talos/nodes/controlplane/k8s-0.yaml.j2
+++ b/talos/nodes/controlplane/k8s-0.yaml.j2
@@ -7,20 +7,3 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
----
-apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
-addresses:
-  - address: 192.168.67.10/24
-routes:
-  - gateway: 192.168.67.1
-    table: 100
----
-apiVersion: v1alpha1
-kind: BGPInstanceConfig
-name: main
-routerID: 192.168.67.10

--- a/talos/nodes/controlplane/k8s-1.yaml.j2
+++ b/talos/nodes/controlplane/k8s-1.yaml.j2
@@ -7,20 +7,3 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
----
-apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
-addresses:
-  - address: 192.168.67.11/24
-routes:
-  - gateway: 192.168.67.1
-    table: 100
----
-apiVersion: v1alpha1
-kind: BGPInstanceConfig
-name: main
-routerID: 192.168.67.11

--- a/talos/nodes/controlplane/k8s-2.yaml.j2
+++ b/talos/nodes/controlplane/k8s-2.yaml.j2
@@ -7,20 +7,3 @@ apiVersion: v1alpha1
 kind: KubeNodeConfig
 labels:
   topology.kubernetes.io/zone: m
----
-apiVersion: v1alpha1
-kind: VLANConfig
-name: bond0.67
-vlanID: 67
-parent: bond0
-mtu: 9000
-addresses:
-  - address: 192.168.67.12/24
-routes:
-  - gateway: 192.168.67.1
-    table: 100
----
-apiVersion: v1alpha1
-kind: BGPInstanceConfig
-name: main
-routerID: 192.168.67.12


### PR DESCRIPTION
This returns the kube API endpoint to the pre-#11391 architecture: `k8s.internal` rides a Cilium LoadBalancer Service (`192.168.69.120`, `externalTrafficPolicy: Local`) announced over Cilium BGP, and the Talos native BGP anycast (`192.168.66.1` on `dummy0`, VLAN 67 peering, policy routing) is removed entirely.

## Why we migrated back

The anycast delivered what it promised: ECMP across all three control plane nodes, failover bounded by a 9s hold timer, and an API path independent of the CNI. The problem is what it cost to keep true.

**The root cause was structural, not a bug.** Talos's BGP speaker advertises host interfaces, so the VIP had to exist as a real global-scope address on every node, and Talos has no concept of an address that is advertised but not identity. Every subsystem that consumes host addresses treated `192.168.66.1` as who the node is:

- The `RoutingRuleConfig` needed to fix same-L2 asymmetric paths (#11392) silently collided with Cilium's relocated local-table rule at priority 100: invisible in `talosctl get routingrule` because Talos keys the resource by `family/priority`, and hijacking all host-local traffic sourced from the VIP. Result: no node could reach the API address from itself, and `talosctl -n k8s-2` failed 80% of the time. Diagnosed and fixed in #11451.
- The boot-time `NodeAddress` election could latch the anycast as a node's default address, poisoning `/etc/hosts` and node identity. The election is latched forever by design and re-races on every reboot; there is no upstream knob to exclude an address.
- Discovery advertised the VIP in every node's member list, so apid's DNS-based dial pool contained an address that self-delivers on the proxying node: a request labeled for one node could be served by another. Closing that required `resolveMemberNames: false` (#11454), which traded away Talos-native name resolution and made apid depend on UDM lease DNS.
- Keeping the VIP out of etcd's `advertisedSubnets`, the kubelet's `nodeIP.validSubnets`, and ARP required the off-subnet `/32`, the dedicated peering VLAN (FRR keys peers by source address and Talos cannot pin a numbered session's source), and the table-100 policy routing, all documented in the attempt to remove them (#11452, closed after review found four defects).
- Advertisement is link-state-driven, not apiserver-health-aware, which required an `api-ready` bootstrap gate to protect unretried helm and kubectl calls.

Each fix was correct in isolation. Together they are perimeter defenses around one missing upstream concept, on a beta feature (`v1.14.0-beta.1`), guarding a three-node homelab API endpoint. Peer review of the original design reached the same conclusion from the other direction.

**What the Cilium LB does better:** `externalTrafficPolicy: Local` means only nodes with a healthy apiserver attract traffic, which is strictly better failover semantics than the anycast's link-state advertisement for the apiserver-down case. The LoadBalancer IP never exists on any host, so none of the identity contamination above is possible; that is why Cilium's BGP produced zero such incidents in years of service.

**What is given up:** a CNI-independent named endpoint. If Cilium is down, the API is reachable at the node IPs directly (`https://192.168.42.10-12:6443`), and the Talos API never depended on any of this. The README documents that fallback.

## Kept from the saga

- `maximum-paths 3` on the UDM (Cilium VIPs get true ECMP; FRR's eBGP default is a single path)
- The `api-ready` bootstrap gate (still guards unretried helm/kubectl against a not-yet-ready apiserver)
- `net/ipv6/conf/bond0.70/disable_ipv6` (#11453, unrelated to BGP)
- The documented lessons, including the upstream ask that remains worth filing: a Talos service-address concept, advertised but excluded from election, discovery, etcd, and kubelet identity

## Restored

- `kube-api` Service in `networking.yaml` (VIP `192.168.69.120`, external-dns `k8s.turbo.ac`)
- Cilium postsync hooks in the bootstrap helmfile (the VIP must exist before Flux takes over)
- The two-phase kubeconfig in `bootstrap/mod.just` (node IP during bootstrap, `k8s.internal` after)
- `resolveMemberNames: true` (with no anycast in member lists, synthesis is harmless again; #11454 is closed as superseded)

## Removed

- `DummyLinkConfig dummy0` / `192.168.66.1`, `BGPInstanceConfig`, `RoutingRuleConfig` from `cluster.yaml.j2`
- `VLANConfig bond0.67`, per-node addresses, table-100 routes, and `routerID`s from the node patches
- `192.168.66.1` from apiserver `certExtraSANs`

## Rollout order (zero downtime)

1. **Merge.** Flux restores the `kube-api` Service; the VIP comes up via Cilium BGP alongside the still-working anycast. Verify: `curl -k https://192.168.69.120:6443/livez`.
2. **UDM: point `k8s.internal` at `192.168.69.120`** and remove the `192.168.66.1` record. Verify kubectl.
3. **Apply Talos configs one node at a time** (no reboot; removes the links, BGP instance, rule, and cert SAN; flips `resolveMemberNames` back). The anycast withdraws node by node; nothing references it after step 2. Removing `bond0.67`'s address also forces the latched default `NodeAddress` on k8s-0/k8s-1 to re-elect to the node IP, curing that as a side effect.
4. **UDM: upload the single-peer-group FRR config** from the README (keeps `maximum-paths 3`), then delete the VLAN 67 network and its trunk tagging.

Rollback at any point before step 4: re-point DNS at `192.168.66.1`; both paths exist until step 3 completes.

## Validated

`talosctl validate -m metal` passes on all three rendered configs with zero BGP-era documents remaining, kustomize and the helmfile parse, and the repo has no residual references to `192.168.66.1`, `192.168.67.x`, or `bond0.67`.