### PR TITLE
feat(home-assistant): add liveness, readiness and startup probes

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -26,6 +26,28 @@ spec:
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8123
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -55,7 +77,7 @@ spec:
         ports:
           http:
             appProtocol: kubernetes.io/ws
-            port: 8123
+            port: *port
     route:
       app:
         annotations:


### PR DESCRIPTION
Adds probes to the Home Assistant HelmRelease, which currently has none.

## Probes

| Probe | Target | Timing |
| --- | --- | --- |
| liveness | `tcpSocket :8123` | period 30s, timeout 5s, 5 failures |
| readiness | `httpGet /healthz` | period 10s, timeout 5s, 5 failures |
| startup | `tcpSocket :8123` | period 10s, 30 failures |

Same shape as the other app-template HelmReleases (zwave, plex, tautulli, atuin): TCP liveness and startup, with a custom HTTP readiness path.

## Readiness target

`/healthz` comes from the [ha-health-check](https://github.com/Tobix99/ha-health-check) HACS integration, configured with a 10s keepalive interval and a 60s unhealthy threshold. It returns 503 once the keepalive is older than the threshold, meaning the event loop has stalled. The handler reports healthy whenever `hass.state != CoreState.running` and whenever a backup is in progress, so startup, shutdown and backups do not pull the pod from the Gateway backend pool.

Home Assistant serves no health endpoint of its own, so this path exists only with the integration installed.

## Verification

Rendered against app-template 5.0.1 with `helm template`:

```yaml
livenessProbe:
  failureThreshold: 5
  initialDelaySeconds: 0
  periodSeconds: 30
  tcpSocket:
    port: 8123
  timeoutSeconds: 5
readinessProbe:
  failureThreshold: 5
  httpGet:
    path: /healthz
    port: 8123
  periodSeconds: 10
  timeoutSeconds: 5
startupProbe:
  failureThreshold: 30
  initialDelaySeconds: 0
  periodSeconds: 10
  tcpSocket:
    port: 8123
  timeoutSeconds: 1
```

Checked against the live pod:

- `/healthz` returns 200 `{"healthy":true}` unauthenticated, 1.6ms median over 12 requests.
- The keepalive sensor `sensor.kubernetes_probes_last_seen` is already matched by the existing `sensor.*_last_seen` glob in `recorder.exclude`, so the handler reads in-memory state and issues no database query per probe.
