### PR TITLE
fix(just): run root recipes under bash with pipefail

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,21 +1,24 @@
 #!/usr/bin/env -S just --justfile
 
+set minimum-version := '1.55.0'
+
 set default-list
 set default-script
 set lazy
 set quiet
+set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 # Bootstrap Recipes
-[group: 'Bootstrap']
+[group('Bootstrap')]
 mod bootstrap "bootstrap"
 
 # Kube Recipes
-[group: 'Kube']
+[group('Kube')]
 mod kube "kubernetes"
 
 # Talos Recipes
-[group: 'Talos']
+[group('Talos')]
 mod talos "talos"
 
 [private]


### PR DESCRIPTION
## Problem

`set default-script` routes every recipe through `script-interpreter`, not `shell`. The three module justfiles set both; the root set only `shell`, so its recipes ran under the default `['sh', '-eu']` and the `set shell` line was inert for them.

The `template` recipe is a pipeline:

```just
template file *args:
    minijinja-cli "{{ file }}" {{ args }} | op inject
```

Without `pipefail`, a failed render exits 0 and `op inject` emits empty or partial output, which then feeds:

- `talosctl machineconfig patch <(just template ...)` (`talos/mod.just`)
- `... | just template - | kubectl apply --server-side --force-conflicts` (`bootstrap/mod.just`)
- `curl --data-binary @<(just template ...)` for the image factory schematic POST (`talos/mod.just`)

Reproduced against the root justfile settings, with a probe recipe running `false | true`:

| | before | after |
|---|---|---|
| `pipefail` | off | on |
| failed pipeline | `exit=0`, execution continues | `recipe failed with exit code 1` |

## Changes

- `set script-interpreter := ['bash', '-euo', 'pipefail']`, matching `bootstrap/mod.just`, `kubernetes/mod.just` and `talos/mod.just`.
- `set minimum-version := '1.55.0'`. The root justfile does not parse below just 1.53.0 (`set default-list` needs 1.52.0, `recipe_name()` needs 1.53.0), and today an older just fails with `call to undefined function recipe_name` pointing into a module. 1.55.0 is the floor worth declaring since that is the release that added the setting; below it just reports `unknown setting`, and 1.55.0+ gets `justfile requires just X or later, but using Y`.
- The `[group: '...']` to `[group('...')]` rewrite is the `format-just` pre-commit hook. Both forms are valid; the file simply had not been through the hook before.

## Verification

- Parses under 1.55.0, 1.57.0 and the pinned 1.58.0; rejected under 1.54.0 as intended.
- `just --list`, `just kube`, `just talos` and `just log` all behave as before.
- `just --fmt --check` clean under 1.58.0 for all four justfiles.