### PR TITLE
chore: deploy home-assistant mcp server

### DIFF
--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -24,3 +24,28 @@ spec:
     namespace: flux-system
   targetNamespace: default
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: home-assistant-mcp
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/home-assistant/mcp
+  postBuild:
+    substitute:
+      APP: home-assistant-mcp
+      KOPIUR_CAPACITY: 1Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/home-assistant/mcp/externalsecret.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-assistant-mcp-secret
+    template:
+      data:
+        HOMEASSISTANT_TOKEN: "{{ .HASS_MCP_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: home-assistant-mcp

--- a/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
@@ -19,11 +19,8 @@ spec:
             image:
               repository: ghcr.io/homeassistant-ai/ha-mcp
               tag: 8.0.0@sha256:d65630f6a3fd14d8f536c27432d4d2cf3045e6f6a2d196cba754ee8566491ae4
-            # The image CMD defaults to stdio transport, which has no listener
             command: ["ha-mcp-web"]
             env:
-              # Explicit data dir, so persistence does not depend on the image's
-              # HOME or on the container uid owning /home/mcpuser
               HA_MCP_CONFIG_DIR: &configDir /config
               HOMEASSISTANT_URL: http://home-assistant.default.svc.cluster.local:8123
               MCP_HEALTHZ: true

--- a/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-assistant-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: home-assistant-mcp
+  interval: 1h
+  values:
+    controllers:
+      home-assistant-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/homeassistant-ai/ha-mcp
+              tag: 8.0.0@sha256:d65630f6a3fd14d8f536c27432d4d2cf3045e6f6a2d196cba754ee8566491ae4
+            # The image CMD defaults to stdio transport, which has no listener
+            command: ["ha-mcp-web"]
+            env:
+              # Explicit data dir, so persistence does not depend on the image's
+              # HOME or on the container uid owning /home/mcpuser
+              HA_MCP_CONFIG_DIR: &configDir /config
+              HOMEASSISTANT_URL: http://home-assistant.default.svc.cluster.local:8123
+              MCP_HEALTHZ: true
+              MCP_HOST: 0.0.0.0
+              MCP_PORT: &port 80
+              TZ: America/New_York
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.turbo.ac"
+          - hass-mcp.turbo.ac
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: *configDir

--- a/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/helmrelease.yaml
@@ -21,7 +21,9 @@ spec:
               tag: 8.0.0@sha256:d65630f6a3fd14d8f536c27432d4d2cf3045e6f6a2d196cba754ee8566491ae4
             command: ["ha-mcp-web"]
             env:
+              FASTMCP_CHECK_FOR_UPDATES: "off"
               HA_MCP_CONFIG_DIR: &configDir /config
+              HA_MCP_DISABLE_UPDATE_CHECK: true
               HOMEASSISTANT_URL: http://home-assistant.default.svc.cluster.local:8123
               MCP_HEALTHZ: true
               MCP_HOST: 0.0.0.0

--- a/kubernetes/apps/default/home-assistant/mcp/kustomization.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/home-assistant/mcp/ocirepository.yaml
+++ b/kubernetes/apps/default/home-assistant/mcp/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-assistant-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Runs [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) as a standalone deployment under `home-assistant/mcp`, instead of the in-process Home Assistant custom component.

## Why

The embedded server currently fails to start:

```
HA-MCP in-process server failed to start:
RichHandler.__init__() got an unexpected keyword argument 'tracebacks_max_frames'
```

`fastmcp` passes `tracebacks_max_frames` to `rich`'s `RichHandler`. Two `rich` installs exist inside the HA container and the wrong one wins:

| location | version | supports the kwarg |
| --- | --- | --- |
| `/usr/local/lib/python3.14/site-packages` (image) | 10.16.2 | no |
| `/config/.venv/lib/python3.14/site-packages` (HACS deps) | 13.9.4 | yes |

The image's `site-packages` sits ahead of `/config/.venv` on `sys.path`, so the 2021-era `rich` shadows the one `fastmcp-slim` correctly pins as `rich>=13.9.4`. It cannot be fixed in place because the container runs `readOnlyRootFilesystem: true`. A separate deployment gets its own dependency tree and sidesteps it.

## Notes

- **`command: ["ha-mcp-web"]`** — the image `CMD` defaults to stdio transport, which has no listener and would never become ready. `ha-mcp-web` maps to `main_web()`, which serves HTTP.
- **`MCP_HEALTHZ: true`** — opts in to the unauthenticated `GET /healthz` route, which upstream documents as being for "uptime monitors, blackbox probes, and load balancers". It is off by default because standard mode authenticates by URL-path secrecy. Enabling it means readiness is a real HTTP probe rather than a TCP check.
- **`HA_MCP_CONFIG_DIR: /config`** — `utils/data_paths.py` checks this before falling back to `~/.ha-mcp`. Setting it explicitly keeps persistence off the image's `HOME`, which would otherwise mean running as the image's uid 999 for `/home/mcpuser` to be writable. Without a writable dir the app silently falls back to `$TMPDIR/ha-mcp` and loses settings on every restart.
- **Backed up via `kopiur`** — the data directory holds `entity_visibility.json` and `tool_policy.json`, which gate which entities the LLM can see and which tools it can call. Neither has an env equivalent (`visibility/persistence.py` and `policy/persistence.py` are file-only), so that access scope cannot live in git. Without a volume it would revert to defaults on every pod recreate, silently.
- **Routed via `envoy-internal`** — it holds a long-lived Home Assistant token. Hostnames follow the same shape as `home-assistant` itself: the templated name plus a short alias, `hass-mcp.turbo.ac`.
- Image is pinned to `8.0.0`, the newest stable tag; upstream also publishes a rapid dev train (`8.0.0.devNNNN`, several per day) that should not be tracked.

## Before merge

Requires the 1Password item `home-assistant-mcp` with a `HASS_MCP_TOKEN` field containing a long-lived access token. The ExternalSecret maps it to `HOMEASSISTANT_TOKEN`, which is the name the container expects.