### PR TITLE
refactor(go2rtc): split config so Home Assistant manages streams

### DIFF
--- a/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
             image:
               repository: ghcr.io/alexxit/go2rtc
               tag: 1.9.14@sha256:675c318b23c06fd862a61d262240c9a63436b4050d177ffc68a32710d9e05bae
+            args:
+              - -config
+              - /state/go2rtc.yaml
+              - -config
+              - /config/go2rtc.yaml
             probes:
               liveness:
                 enabled: true
@@ -42,6 +47,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         forceRename: "{{ .Release.Name }}"
@@ -93,13 +100,6 @@ spec:
               ice_servers:
                 - urls:
                     - stun:stun.cloudflare.com:3478
-            streams:
-              driveway:
-                - rtspx://192.168.1.1:7441/SB74mRIu1CkoPcEq
-              garage:
-                - rtspx://192.168.1.1:7441/dFl352XtCUFREtRz
-              porch:
-                - rtspx://192.168.1.1:7441/ezkTDbaOR71GUE67
     persistence:
       config-file:
         type: configMap
@@ -107,3 +107,7 @@ spec:
         globalMounts:
           - path: /config/go2rtc.yaml
             subPath: go2rtc.yaml
+      state:
+        type: emptyDir
+        globalMounts:
+          - path: /state


### PR DESCRIPTION
Home Assistant's core `go2rtc` integration registers camera streams over the API, and go2rtc persists those by rewriting its config file. With the ConfigMap mounted read-only, that write fails:

```
400 Bad Request
open /config/go2rtc.yaml: read-only file system
```

The stream still lands in go2rtc's runtime, so it self-corrects on retry, but every camera burns one failed load after each HA or go2rtc restart.

## Approach

`go2rtc -config` is repeatable. Verified against 1.9.14:

- all files are merged for reading
- writes go only to the **first** file
- a missing first file is not an error at startup, and go2rtc creates it on first write

So the writable `emptyDir` goes first and the ConfigMap second. The ConfigMap stays authoritative and read-only in git; HA's dynamic registrations land in disposable state. No initContainer needed.

## Dropping the hardcoded streams

`driveway`, `garage` and `porch` pinned `rtspx://` URLs containing UniFi Protect tokens, which rotate when camera settings change. HA now supplies stream sources from the `unifiprotect` integration, so they're redundant.

Verified working before this change: all three cameras stream over WebRTC through go2rtc (`consumers=1` each), on LAN and remotely via STUN.

## Notes

`fsGroup: 1000` is required for the emptyDir to be writable under `runAsUser: 1000` / `runAsNonRoot: true`.

On rollout, go2rtc restarts and loses its runtime streams. HA re-registers them on next view, and that first write now succeeds.