### PR TITLE
fix(go2rtc): keep binary name in args, drop RollingUpdate override

### DIFF
--- a/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     controllers:
       go2rtc:
-        strategy: RollingUpdate
+        strategy: Recreate
         containers:
           app:
             image:

--- a/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
@@ -19,6 +19,7 @@ spec:
               repository: ghcr.io/alexxit/go2rtc
               tag: 1.9.14@sha256:675c318b23c06fd862a61d262240c9a63436b4050d177ffc68a32710d9e05bae
             args:
+              - go2rtc
               - -config
               - /state/go2rtc.yaml
               - -config

--- a/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/default/go2rtc/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
   values:
     controllers:
       go2rtc:
-        strategy: Recreate
         containers:
           app:
             image:


### PR DESCRIPTION
Follow-up to #11474, which broke the go2rtc rollout.

## Binary name in args

The image entrypoint is `/sbin/tini --` and the binary comes from CMD (`go2rtc -config /config/go2rtc.yaml`). Overriding `args` replaced the entire CMD including the binary name, so tini tried to exec `-config`:

```
[FATAL tini (7)] exec -config failed: No such file or directory
```

Container exited 127 and crash-looped. RollingUpdate held the previous pod, so cameras stayed up throughout.

## Drop the RollingUpdate override

`replicas` is already 1, but `RollingUpdate` with `maxSurge: 25%` rounds up to one extra pod, so a second instance runs during every rollout.

That is wrong for this workload:

- the `streams` LoadBalancer uses `externalTrafficPolicy: Local`, so two pods on different nodes split traffic
- both instances pull the same RTSP producers from UniFi Protect
- with stream state now in an emptyDir (#11474) each pod keeps its own, so registrations made against one are absent from the other

`Recreate` is the app-template default, so removing the override is sufficient — no explicit setting needed.