### PR TITLE
chore(home-assistant): drop unused HTTP trusted proxy env vars

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
               tag: 2026.8.0@sha256:99c0293b3ad103151a9d8b860232fd1c6db425eadb9eb4905c0ecbef65b27363
             env:
               TZ: America/New_York
-              HASS_HTTP_TRUSTED_PROXY_1: 192.168.69.0/24
-              HASS_HTTP_TRUSTED_PROXY_2: 10.42.0.0/16
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"


### PR DESCRIPTION
Home Assistant 2026.8 deprecates the `http:` YAML block (Repairs flags it as `deprecated_yaml`, breaking in 2027.2.0) and imports it into `.storage/http` on first start.

The import resolves both `!env_var` references to their literal CIDRs, so `HASS_HTTP_TRUSTED_PROXY_1` and `HASS_HTTP_TRUSTED_PROXY_2` are no longer read by anything.

## Verification

The `http:` block has been removed from `configuration.yaml` on the PVC and Home Assistant restarted. Settings confirmed intact in `.storage/http` afterwards:

```json
{
  "ip_ban_enabled": true,
  "login_attempts_threshold": 10,
  "use_x_forwarded_for": true,
  "trusted_proxies": ["192.168.69.0/24", "10.42.0.0/16"],
  "server_port": 8123
}
```

Post-restart state: 0 repairs, 0 errors, 51/51 automations enabled, integration entity counts unchanged.

## Note

These values are now stored in `.storage` on the PVC rather than declared here, so they fall under Kopia backups instead of git.