### PR TITLE
chore(renovate-config)!: update config home-operations/renovate-presets (5.0.0 ➔ 6.0.0)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>home-operations/renovate-presets#5.0.0", ":timezone(America/New_York)"],
+  extends: [
+    "github>home-operations/renovate-presets#6.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#6.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0",
+    ":timezone(America/New_York)",
+  ],
   lockFileMaintenance: {
     enabled: true,
     schedule: ["before 3am on the first day of the month"],


### PR DESCRIPTION
Closes #11489

## Why

The `#5.0.0` pin only pinned the entry point. `default.json` at that tag lists its nested presets without a tag, and Renovate resolves each nested reference from the preset repo's default branch. home-operations/renovate-presets#86 moved the app-specific presets out of `managers/` and `versioning/` into an opt-in `apps/` directory, so `default.json@5.0.0` kept asking for `managers/cnpg.json5`, which no longer exists on main. Preset resolution failed and Renovate halted every PR.

## What

Bump to `6.0.0`, whose `default.json` matches the new layout, and explicitly opt into the two `apps/` presets this repo actually needs:

- `apps/grafanaDashboards.json5` - 13 `grafanadashboard.yaml` manifests under `kubernetes/apps/`, plus the existing auto-merge rule that matches the `custom.grafana-dashboards` datasource.
- `apps/talosFactory.json5` - the `factory.talos.dev` installer image in `talos/cluster.yaml.j2`, and the rule that stops the generic Docker manager from double-matching it.

`cnpg`, `llamacpp`, `phanpy` and `searxng` also moved but are unused here, so they stay out.

## Verification

Ran `renovate --platform=local --dry-run=lookup` against a fixture holding this config, `talos/cluster.yaml.j2` and a `grafanadashboard.yaml`:

- The same config on `main` reproduces the exact issue error: `Cannot find preset's package (github>home-operations/renovate-presets//managers/cnpg.json5)`.
- This branch resolves all presets with no preset error, and both custom managers still extract: `siderolabs/talos` `v1.14.0-beta.1` via `custom.talos-factory`, and dashboard `13524` rev `1` via `custom.grafana-dashboards`.