### PR TITLE
chore: move Intel iGPU back to i915, drop kata-containers and plex-next

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -17,8 +17,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/home-operations/plex-next
-              tag: 1.43.3.10861@sha256:7b4b0d75d9159172cbb07f62a5892d4f0d0f722083bf16cf5ba7c482f2dcaa0b
+              repository: ghcr.io/home-operations/plex
+              tag: 1.43.3.10861@sha256:235402dacb4c66224052de3dfd4c444044e792185ab27dc83b5c200a55370492
             env:
               TZ: America/New_York
               PLEX_ADVERTISE_URL: https://plex.turbo.ac:443,http://192.168.69.128:32400,http://plex.default.svc.cluster.local:32400

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -1,6 +1,7 @@
 ---
 customization:
   extraKernelArgs:
+    - i915.enable_guc=3 # Meteor Lake CPU & Intel iGPU
     - intel_iommu=on # PCI Passthrough
     - iommu=pt # PCI Passthrough
     - module_blacklist=igc # Thunderbolt NICs (disable igc)

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -1,8 +1,6 @@
 ---
 customization:
   extraKernelArgs:
-    - i915.force_probe=!7d55 # Intel iGPU (disable i915)
-    - xe.force_probe=7d55 # Intel iGPU (enable xe)
     - intel_iommu=on # PCI Passthrough
     - iommu=pt # PCI Passthrough
     - module_blacklist=igc # Thunderbolt NICs (disable igc)
@@ -13,7 +11,5 @@ customization:
       - siderolabs/drbd # Miroir DRBD9 Replication
       - siderolabs/i915 # Intel iGPU
       - siderolabs/intel-ucode # Intel iGPU
-      - siderolabs/kata-containers # Home Operations Org Runners
       - siderolabs/mei # Intel iGPU
       - siderolabs/thunderbolt # Thunderbolt NICs
-      - siderolabs/xe # Intel iGPU


### PR DESCRIPTION
Moves the Intel iGPU off `xe` and back to `i915`, drops the unused `kata-containers` extension, and returns Plex to the Ubuntu image.

## Why

`k8s-1` has hard-hung on three nights since the Talos 1.14 (kernel 6.18) upgrade. A deliberate HDR tone-map benchmark reproduced an `xe` GuC timeout and engine reset on demand:

```
xe 0000:00:02.0: [drm] Tile0: GT0: Suspend fence, guc_id=7, failed to respond
xe 0000:00:02.0: [drm] VM worker error: -62            (ETIME)
xe 0000:00:02.0: [drm] Tile0: GT0: trying reset from disable_scheduling_deregister [xe]
xe 0000:00:02.0: [drm] Tile0: GT0: reset started / reset done
```

That was the only `xe` reset in the retained dmesg, with none across hours of ordinary non-HDR VAAPI transcodes before it.

This signature matches known `xe`-driver defects on Meteor Lake, all in code that has no `i915` equivalent:

- [`drm/xe/guc: Don't ban LR VM exec queues on PM suspend`](https://lists.freedesktop.org/) - `xe_guc_submit_stop()` bans exec queues holding started-but-incomplete jobs during a GT reset or suspend, which is the `Suspend fence ... failed to respond` plus `disable_scheduling_deregister` path seen above.
- [`drm/xe/sched: stop re-submitting signalled jobs`](https://lists.ubuntu.com/) - engine resets caused by re-submitting already-completed jobs.
- [Launchpad #2161220](https://bugs.launchpad.net/) - `xe` on Meteor Lake-P (GPU ID `7d55`, this exact device) wants GuC firmware 70.44.1; older blobs produce GPU reset storms.

## Changes

**Kernel args and the xe extension.** `siderolabs/xe` ships the driver itself, not just firmware:

```
$ cat drm/xe/files/modules.txt
kernel/drivers/gpu/drm/xe/xe.ko
```

so removing the extension removes `xe.ko` from the node entirely, and `xe.force_probe` has nothing left to act on. `i915.force_probe=!7d55` goes with it because `mtl_info` in `drivers/gpu/drm/i915/i915_pci.c` carries no `require_force_probe` (the only struct in that file which does is `ats_m_info`). `i915` therefore binds `7d55` unconditionally and is the sole remaining candidate. `siderolabs/i915` is kept and ships `i915.ko` the same way.

`i915.enable_guc=3` is restored to pin the behaviour explicitly. On Meteor Lake the `-1` default already expands to `ENABLE_GUC_LOAD_HUC | ENABLE_GUC_SUBMISSION` in `uc_expand_default_options()`, so it changes nothing today. It is set so that GuC submission and HuC load cannot drift with a future kernel default. The value only ever mattered on pre-Gen12, TGL/RKL and ADL-S, which take earlier branches in that function.

**kata-containers.** No consumers: no `RuntimeClass` in this repo, and `kubectl get runtimeclass` returns nothing. Cilium stays on `veth`.

**Plex.** Back to `ghcr.io/home-operations/plex`, same version `1.43.3.10861`. The Ubuntu image needs no workaround for hardware tone mapping: Plex downloads its own Intel Compute Runtime into the config volume, and its ICD resolves the compiler backend through an `$ORIGIN` RUNPATH that glibc honours for a `dlopen` and musl does not.

## Caveats

**This does not escape GuC.** `i915` on Meteor Lake uses GuC submission too, with no execlist fallback on this hardware. The bugs above are `xe`-side scheduler and PM logic rather than GuC firmware faults, so avoiding that code is the point, but `i915` has its own Meteor Lake GuC hang reports and the firmware version still matters. After the first node is up, check the reported version:

```sh
talosctl -n k8s-0 dmesg | grep -i 'GuC firmware'
```

**`xe` was not the variable that changed.** It landed 2026-06-18 and ran clean for five and a half weeks; the hangs began the night after the 2026-07-26 kernel bump. If hangs continue on `i915`, the kernel remains suspect and reverting Talos to 1.13.7 is the cleaner single-variable test.

## Apply

Schematic changes need a new Image Factory ID and a powercycle per node:

```sh
just talos schematic-id
just talos upgrade-node k8s-0     # verify, then k8s-1, k8s-2
```

Post-upgrade checks:

```sh
talosctl -n k8s-0 read /sys/bus/pci/devices/0000:00:02.0/uevent   # expect DRIVER=i915
kubectl get resourceslices                                        # gpu.intel.com still published
```

Then confirm Plex reports `transcodeHwFullPipeline: true` once it lands on an upgraded node. Note that `i915` hang messages read differently (`GPU HANG`, `Resetting rcs0`), so greps tuned for `xe` will not match.

## Follow-up

`kubernetes/apps/kube-system/cilium/app/helmrelease.yaml` still justifies `datapathMode: veth` with a comment about `kata-containers`, which this PR removes. Left alone deliberately since Cilium stays on veth either way.
