### PR TITLE
feat(talos): update siderolabs/talos (v1.14.0-beta.1 ➔ v1.14.0-rc.1)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.14.0-beta.1
+    version: v1.14.0-rc.1
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -69,7 +69,7 @@ clusterSecret: op://kubernetes/talos/CLUSTER_SECRET
 apiVersion: v1alpha1
 kind: UnattendedInstallConfig
 installer:
-  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-beta.1
+  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-rc.1
 provisioning:
   diskSelector:
     match: disk.model == "MK000480GWCEV"


### PR DESCRIPTION
Bumps Talos from v1.14.0-beta.1 to v1.14.0-rc.1 ([release notes](https://github.com/siderolabs/talos/releases/tag/v1.14.0-rc.1)). There is no rc.0; upstream went straight from beta.1 to rc.1.

Pre-flight checks against this cluster:

- Image Factory serves v1.14.0-rc.1 and all five schematic extensions (drbd, i915, intel-ucode, mei, thunderbolt) are available for it.
- DRBD driver is unchanged at 9.3.3, so miroir only sees a module rebuild for the new kernel.
- The etcd HTTP endpoints moving to port 2383 does not affect metrics here: `listen-metrics-urls` is pinned to :2381, which stays put, so the kube-prometheus-stack `kubeEtcd` scrape is unaffected.
- Workload isolation (sandboxd) is opt-in via `SecurityProfileConfig`, which this config does not set; upgraded nodes keep current behavior.
- Kernel goes 6.18.41 to 6.18.44; nothing in the delta applies to this IPv4/Cilium setup.

tuppr rolls the nodes with the existing Ceph and kopiur health gates. Post-upgrade: check DRBD resync state (miroir issue #397 can park a resync in WFBitMapS during rolling reboots) and watch k8s-1 overnight.