### PR TITLE
fix(rook-ceph): rotate cephx daemon keys for CVE-2025-30156

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -38,6 +38,11 @@ spec:
         osd:
           limits:
             memory: 8Gi # Required for bootstrap
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
       storage:
         devicePathFilter: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA800TFS_.*
         useAllDevices: false


### PR DESCRIPTION
## Description

Ceph v19.2.6 (applied in #11542 via the rook-ceph v1.19.9 chart group) is the hotfix release for [CVE-2025-30156](https://docs.ceph.com/en/latest/security/CVE-2025-30156/): CephX AES-128-CBC service tickets lack integrity protection, allowing a low-privilege key holder on the cluster network to escalate to admin. The upgrade alone does not resolve the CVE; the core daemon keys must be rotated to the new `aes256k` key type.

This sets `spec.security.cephx.daemon` to `keyRotationPolicy: KeyGeneration` with `keyGeneration: 2`, which has the operator rotate mon/mgr/osd/mds and admin keys to `aes256k` with rolling daemon restarts. PVCs stay online throughout.

Expected behavior after merge:

- The `AUTH_INSECURE_SERVICE_KEY_TYPE` HEALTH_ERR clears once rotation completes.
- `AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` self-clears 2-3 hours later.
- `AUTH_INSECURE_CLIENT_KEY_TYPE` / `KEYS_ALLOWED` / `KEYS_CREATABLE` warnings remain: CSI keys must stay `aes` because aes256k kernel mounts require Linux 7.0+ and the Talos nodes run 6.18. The operator already pins `csi.keyType: aes`.

Verification: `kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.cephx}'` should show `keyGeneration: 2` and `keyCephVersion: 19.2.6-0` for mon/mgr/osd/admin, and the CephFilesystem `status.cephx.daemon` likewise.

Reference: [Rook CephX Keys and Rotation](https://github.com/rook/rook/blob/v1.19.9/Documentation/Storage-Configuration/Advanced/cephx-key-rotation.md) (CVE quick resolution guide).