### PR TITLE
refactor(flux): rely on eventual consistency instead of rook-ceph-cluster dependency

### DIFF
--- a/kubernetes/apps/default/agregarr/ks.yaml
+++ b/kubernetes/apps/default/agregarr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/agregarr/app
   postBuild:

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -8,8 +8,8 @@ spec:
   components:
     - ../../../../components/kopiur/backup
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/atuin/app
   postBuild:

--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/autobrr/app
   postBuild:

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/bazarr/app
   postBuild:

--- a/kubernetes/apps/default/brrpolice/ks.yaml
+++ b/kubernetes/apps/default/brrpolice/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/brrpolice/app
   postBuild:

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -10,8 +10,8 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: kube-system
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/home-assistant/app
   postBuild:
@@ -34,8 +34,8 @@ spec:
   components:
     - ../../../../components/kopiur/backup
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/home-assistant/mcp
   postBuild:

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -11,8 +11,8 @@ spec:
   dependsOn:
     - name: intel-gpu-resource-driver
       namespace: kube-system
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/plex/app
   postBuild:

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/prowlarr/app
   postBuild:

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/qbittorrent/app
   postBuild:

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/qui/app
   postBuild:

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/radarr/app
   postBuild:

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -8,8 +8,8 @@ spec:
   components:
     - ../../../../components/kopiur/backup
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/recyclarr/app
   postBuild:

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/sabnzbd/app
   postBuild:

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/seerr/app
   postBuild:

--- a/kubernetes/apps/default/slskd/ks.yaml
+++ b/kubernetes/apps/default/slskd/ks.yaml
@@ -11,8 +11,8 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: kube-system
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/slskd/app
   postBuild:

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/sonarr/app
   postBuild:

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/tautulli/app
   postBuild:

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -8,8 +8,8 @@ spec:
   components:
     - ../../../../components/kopiur/backup
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/thelounge/app
   postBuild:

--- a/kubernetes/apps/default/zwave/ks.yaml
+++ b/kubernetes/apps/default/zwave/ks.yaml
@@ -9,8 +9,8 @@ spec:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
   dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
+    - name: kopiur
+      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/zwave/app
   postBuild:

--- a/kubernetes/apps/o11y/grafana-operator/ks.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/ks.yaml
@@ -23,8 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: grafana-operator
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/o11y/grafana-operator/instance
   prune: true

--- a/kubernetes/apps/o11y/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: kube-prometheus-stack
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/o11y/kube-prometheus-stack/app
   prune: true

--- a/kubernetes/apps/o11y/victoria-logs/ks.yaml
+++ b/kubernetes/apps/o11y/victoria-logs/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: victoria-logs
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/o11y/victoria-logs/app
   prune: true


### PR DESCRIPTION
## Description

Removes the `dependsOn: rook-ceph-cluster` edge from 22 app Kustomizations and relies on eventual consistency for storage ordering instead.

Rationale:

- No app Kustomization contains rook-owned CRDs or CRs, so every manifest applies cleanly with or without Ceph. At bootstrap, PVCs sit Pending until the CSI driver and `ceph-block` StorageClass appear, then everything binds and starts. Kubernetes handles the ordering natively.
- The dependency actively hurts during storage maintenance: `rook-ceph-cluster` has a `healthCheckExprs` that marks it failed on `HEALTH_ERR`, so all dependents are blocked from reconciling while Ceph is unhealthy. The CVE-2025-30156 key rotation (#11543) put the cluster in an expected, benign `HEALTH_ERR` for about 90 minutes, during which none of these apps could apply changes.
- `dependsOn` only gates applying new manifests; it never protects already-running workloads.

Changes:

- `default/` apps (19 files): the `rook-ceph-cluster` dependency is replaced with a direct dependency on `kopiur`. These apps were relying on the transitive `rook-ceph-cluster -> kopiur` edge to guarantee the kopiur CRDs and ClusterRepository exist before their `Restore`-populated PVCs are created (`onMissingSnapshot: Continue` could otherwise hand back an empty volume on a restore-from-scratch bootstrap). That guarantee is now explicit.
- `o11y/` apps (3 files: grafana-instance, kube-prometheus-stack, victoria-logs): the dependency is removed outright; they only consume storage via PVCs.
- The `rook-ceph -> rook-ceph-cluster` edge and its health checks are unchanged; the health expression remains useful as a signal without gating unrelated apps.