### PR TITLE
refactor(flux): bootstrap kopiur crds via helmfile and drop kopiur dependsOn

### DIFF
--- a/bootstrap/helmfile/crds.yaml
+++ b/bootstrap/helmfile/crds.yaml
@@ -27,5 +27,8 @@ releases:
   - name: grafana-operator
     namespace: o11y
 
+  - name: kopiur
+    namespace: kopiur-system
+
   - name: kube-prometheus-stack
     namespace: o11y

--- a/kubernetes/apps/default/agregarr/ks.yaml
+++ b/kubernetes/apps/default/agregarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/agregarr/app
   postBuild:

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/atuin/app
   postBuild:

--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/autobrr/app
   postBuild:

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/bazarr/app
   postBuild:

--- a/kubernetes/apps/default/brrpolice/ks.yaml
+++ b/kubernetes/apps/default/brrpolice/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/brrpolice/app
   postBuild:

--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -10,8 +10,6 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: kube-system
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/home-assistant/app
   postBuild:
@@ -33,9 +31,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/home-assistant/mcp
   postBuild:

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -11,8 +11,6 @@ spec:
   dependsOn:
     - name: intel-gpu-resource-driver
       namespace: kube-system
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/plex/app
   postBuild:

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/prowlarr/app
   postBuild:

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/qbittorrent/app
   postBuild:

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/qui/app
   postBuild:

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/radarr/app
   postBuild:

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/recyclarr/app
   postBuild:

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/sabnzbd/app
   postBuild:

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/seerr/app
   postBuild:

--- a/kubernetes/apps/default/slskd/ks.yaml
+++ b/kubernetes/apps/default/slskd/ks.yaml
@@ -11,8 +11,6 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: kube-system
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/slskd/app
   postBuild:

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/sonarr/app
   postBuild:

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/tautulli/app
   postBuild:

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/thelounge/app
   postBuild:

--- a/kubernetes/apps/default/zwave/ks.yaml
+++ b/kubernetes/apps/default/zwave/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: kopiur
-      namespace: kopiur-system
   interval: 1h
   path: ./kubernetes/apps/default/zwave/app
   postBuild:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -23,8 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: rook-ceph
-    - name: kopiur
-      namespace: kopiur-system
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease


### PR DESCRIPTION
## Description

Follow-up to #11544, completing the flattening of the app dependency graph.

- Adds kopiur to `bootstrap/helmfile/crds.yaml` so its CRDs are installed out-of-band at bootstrap, matching the file's stated purpose and the existing grafana-operator / kube-prometheus-stack pattern. The helmfile template resolves the chart and version from `kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml`, so the pinned version (and Renovate bumps) are tracked automatically. Verified `helmfile -l name=kopiur template` renders all 9 kopiur CRDs.
- Removes `dependsOn: kopiur` from the 19 `default/` app Kustomizations added in #11544. With CRDs present from bootstrap, app manifests apply cleanly before the kopiur controller exists, and PVC populator semantics (`dataSourceRef` -> `Restore`) hold PVCs Pending until kopiur acts, so no ordering edge is needed.
- Removes the pre-existing `dependsOn: kopiur` from `rook-ceph-cluster`. The rook-ceph manifests contain no kopiur resources; the edge only existed to give apps a transitive kopiur guarantee back when they depended on `rook-ceph-cluster`, which #11544 removed.

Ordering guarantees for the repository connection are unchanged: apps never depended on `kopiur-repository`, and `Restore` handling of an unavailable repository is kopiur's concern rather than a Flux graph concern.

No runtime effect on the live cluster; CRDs already exist and only reconcile gating changes.