### PR TITLE
refactor(flux): drop availability-gating dependsOn edges

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -23,10 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: actions-runner-controller
-    - name: miroir-config
-      namespace: miroir-system
-    - name: generic-device-plugin
-      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur/backup
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: intel-gpu-resource-driver
-      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/default/plex/app
   postBuild:

--- a/kubernetes/apps/kube-system/drm-exporter/ks.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: drm-exporter
 spec:
-  dependsOn:
-    - name: intel-gpu-resource-driver
   interval: 1h
   path: ./kubernetes/apps/kube-system/drm-exporter/app
   prune: true

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
-  dependsOn:
-    - name: certificates-import
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
   prune: true


### PR DESCRIPTION
## Description

Final follow-up to #11544 and #11545: removes the five remaining `dependsOn` edges that gate on resource availability rather than apply-time correctness. Kubernetes handles each of these natively, and the edges only add coupling where an unhealthy infra Kustomization blocks unrelated app updates.

- `plex -> intel-gpu-resource-driver` and `drm-exporter -> intel-gpu-resource-driver`: both consume the GPU via DRA (`ResourceClaimTemplate` with `deviceClassName: gpu.intel.com`). ResourceClaims are built-in `resource.k8s.io` APIs, not CRDs, so manifests always apply; pods stay Pending until the driver publishes devices.
- `actions-runner-controller-runners -> generic-device-plugin`: extended-resource availability; runner pods pend until the plugin advertises the device.
- `actions-runner-controller-runners -> miroir-config`: storage availability; runner PVCs pend until the StorageClass/CSI exists. Miroir maintenance no longer gates runner updates. The `actions-runner-controller` dependency stays (AutoscalingRunnerSet CRDs ship with the controller chart).
- `envoy-gateway -> certificates-import`: Envoy Gateway watches the listener certificate secret and programs it whenever it appears, so it self-heals; the edge meant an external-secrets or 1Password blip could block gateway updates. This hunk is separable if you would rather keep it.

Operator-to-instance CRD edges and the multus NAD edges are untouched, per the dependency review.

No runtime effect on the live cluster; only reconcile gating changes.