### PR TITLE
refactor(flux): bootstrap snapshot-controller crds via helmfile

### DIFF
--- a/bootstrap/helmfile/crds.yaml
+++ b/bootstrap/helmfile/crds.yaml
@@ -32,3 +32,6 @@ releases:
 
   - name: kube-prometheus-stack
     namespace: o11y
+
+  - name: snapshot-controller
+    namespace: kube-system

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: miroir
 spec:
-  dependsOn:
-    - name: snapshot-controller
-      namespace: kube-system
   interval: 1h
   path: ./kubernetes/apps/miroir-system/miroir/app
   prune: true


### PR DESCRIPTION
## Description

Adds snapshot-controller to `bootstrap/helmfile/crds.yaml` so the external-snapshotter CRDs (6 total, including the volume-group-snapshot set) are installed out-of-band at bootstrap. Verified `helmfile -l name=snapshot-controller template` renders all 6; the version tracks `kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml` automatically.

This closes a bootstrap ordering gap surfaced while reviewing kopiur's snapshot dependency: the rook-ceph-cluster HelmRelease renders VolumeSnapshotClass objects (`cephBlockPoolsVolumeSnapshotClass` / `cephFileSystemVolumeSnapshotClass`), which fail helm install while the snapshot CRDs are absent. With #11544 having removed the dependency chain that happened to order snapshot-controller first, a fresh bootstrap would have left that HelmRelease failing on helm-controller's slow retry path until snapshot-controller reconciled. CRDs at bootstrap remove the race entirely.

Also drops the now-redundant `miroir -> snapshot-controller` edge, which guarded miroir's `volumesnapshotclass.yaml` for the same reason. Kopiur itself needs nothing: its chart only references `snapshot.storage.k8s.io` in RBAC rules, and its runtime VolumeSnapshot usage retries harmlessly.

No runtime effect on the live cluster; the CRDs already exist there.