### PR TITLE
feat(sonarr): set allowed hosts and trusted networks

### DIFF
--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: sonarr.turbo.ac,sonarr.default.svc.cluster.local
               SONARR__SERVER__PORT: &port 80
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
               TZ: America/New_York
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Sonarr 4.0.19.3006 (develop, built 2026-08-24) added hostname validation and a trusted networks setting (Sonarr/Sonarr@5f69ab0954, Sonarr/Sonarr@22f05a4343). Both are currently unset, which leaves host filtering at wildcard and raises an `AllowedHostsCheck` health warning since auth is `DisabledForLocalAddresses`.

- `SONARR__SERVER__ALLOWEDHOSTS`: external hostname plus `sonarr.default.svc.cluster.local`, which is what prowlarr, recyclarr, and cleanrr all use. Loopback and the pod hostname are always allowed, covering the in-pod webhook scripts.
- `SONARR__SERVER__TRUSTEDNETWORKS`: pod CIDR, restoring trust of `X-Forwarded-For` from envoy; the upstream change dropped the previously hardcoded RFC1918 trust so client IPs were logging as the envoy pod IP.
- Readiness probe sends `Host: localhost`; the kubelet otherwise uses the pod IP as the Host header, which host filtering rejects. Liveness and startup probes are TCP and unaffected.

Verified by rendering app-template 5.1.0 with the updated values.