### PR TITLE
feat(talos): update siderolabs/talos (v1.14.0-rc.1 ➔ v1.14.0-rc.2)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.14.0-rc.1
+    version: v1.14.0-rc.2
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -69,7 +69,7 @@ clusterSecret: op://kubernetes/talos/CLUSTER_SECRET
 apiVersion: v1alpha1
 kind: UnattendedInstallConfig
 installer:
-  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-rc.1
+  image: factory.talos.dev/metal-installer/{{ schematic }}:v1.14.0-rc.2
 provisioning:
   diskSelector:
     match: disk.model == "MK000480GWCEV"


### PR DESCRIPTION
Bumps Talos from v1.14.0-rc.1 to v1.14.0-rc.2 in the tuppr TalosUpgrade spec and the factory installer image in `talos/cluster.yaml.j2`.

Changes between rc.1 and rc.2 are bugfixes plus component bumps:

- kernel 6.18.44 ➔ 6.18.46, containerd 2.3.3 ➔ 2.3.4, Go 1.26.7
- fix: reduce stalls in the etcd member promotion cycle
- fix: preserve selected sd-boot entry on upgrade
- fix: persist in-memory meta on fresh install
- fix: watch IPv6 route changes in RouteSpecController
- fix: enable SELinux to work with overlays
- fix: install conntrack handler in accept ingress firewall mode

Release notes: https://github.com/siderolabs/talos/releases/tag/v1.14.0-rc.2